### PR TITLE
feat(terminal): summonable site-wide terminal overlay

### DIFF
--- a/v2-blog/eleventy.config.ts
+++ b/v2-blog/eleventy.config.ts
@@ -107,6 +107,10 @@ export default function (eleventyConfig: any) {
       {
         input: './src/assets/styles/menu-mobile-shadow.css',
         output: './dist/assets/css/menu-mobile-shadow.css'
+      },
+      {
+        input: './src/assets/styles/terminal-overlay-shadow.css',
+        output: './dist/assets/css/terminal-overlay-shadow.css'
       }
     ];
 

--- a/v2-blog/src/_helpers/terminal/summon.ts
+++ b/v2-blog/src/_helpers/terminal/summon.ts
@@ -1,0 +1,64 @@
+/**
+ * Tests whether a keyboard event is the terminal summon combo (Ctrl/Cmd + Shift + C).
+ *
+ * Matches on `event.code` ("KeyC") rather than `event.key` so the combo is
+ * independent of keyboard layout and the OS-dependent casing of the produced
+ * character. Callers must NOT preventDefault on a match: on Windows/Linux the
+ * browser opens DevTools alongside the terminal, which is intended.
+ *
+ * @param event - The keydown event to test.
+ * @returns `true` when the event is the summon combo.
+ */
+export function matchesSummonCombo(event: KeyboardEvent): boolean {
+  return (event.ctrlKey || event.metaKey) && event.shiftKey && event.code === "KeyC";
+}
+
+/** Custom element tag for the lazily-loaded overlay. */
+const OVERLAY_TAG = "terminal-overlay";
+/** Built URL of the overlay bundle, lazy-loaded on first summon. */
+const OVERLAY_SRC = "/components/terminal-overlay.js";
+
+/**
+ * Installs the site-wide terminal summoner on a window.
+ *
+ * Listens (capture phase) for the summon combo and, on the first match,
+ * lazy-loads the overlay bundle and mounts a single `<terminal-overlay>`.
+ * Never calls preventDefault: on Windows/Linux DevTools opens alongside the
+ * terminal, which is intended.
+ *
+ * @param target - The window to attach the listener to (defaults to `window`).
+ * @returns A disposer that removes the listener.
+ */
+export function createSummoner(target: Window = window): () => void {
+  const doc = target.document;
+  let overlayEl: HTMLElement | null = null;
+  let scriptInjected = false;
+
+  /** Lazily loads the overlay bundle and mounts the element once. */
+  const ensureOverlay = (): HTMLElement => {
+    if (!scriptInjected) {
+      scriptInjected = true;
+      const script = doc.createElement("script");
+      script.type = "module";
+      script.src = OVERLAY_SRC;
+      doc.head.appendChild(script);
+    }
+
+    if (!overlayEl) {
+      overlayEl = doc.createElement(OVERLAY_TAG);
+      doc.body.appendChild(overlayEl);
+    }
+
+    return overlayEl;
+  };
+
+  /** Opens the overlay on a matching combo without suppressing the event. */
+  const onKeydown = (event: KeyboardEvent): void => {
+    if (!matchesSummonCombo(event)) return;
+    ensureOverlay().setAttribute("open", "");
+  };
+
+  target.addEventListener("keydown", onKeydown, true);
+
+  return () => target.removeEventListener("keydown", onKeydown, true);
+}

--- a/v2-blog/src/_layouts/base.njk
+++ b/v2-blog/src/_layouts/base.njk
@@ -83,6 +83,7 @@
 
     <script type="module" src="/components/theme-toggle.js"></script>
     <script type="module" src="/components/menu-mobile.js"></script>
+    <script type="module" src="/components/terminal-summoner.js"></script>
 
     {% if pageModules %}
       {% for url in pageModules %}

--- a/v2-blog/src/assets/styles/terminal-overlay-shadow.css
+++ b/v2-blog/src/assets/styles/terminal-overlay-shadow.css
@@ -1,0 +1,6 @@
+@source "../../components/terminal-overlay.ts";
+
+@import "tailwindcss/theme.css" layer(theme) prefix(sw);
+@import "tailwindcss/utilities.css" layer(utilities) prefix(sw);
+
+@import "./shadow-config.css";

--- a/v2-blog/src/components/terminal-overlay.ts
+++ b/v2-blog/src/components/terminal-overlay.ts
@@ -1,0 +1,287 @@
+import { css, html, LitElement, PropertyValues } from "lit";
+import { customElement, property, query } from "lit/decorators.js";
+import { adoptTailwind } from "../_helpers/styleLoader.ts";
+import { animator } from "../_helpers/animationManager.ts";
+import { CommandType, TerminalCore } from "../_helpers/terminal/core.ts";
+import type { ParsedCommand } from "../_helpers/terminal/parser.ts";
+
+/**
+ * Site-wide summonable terminal overlay (the "cheat console").
+ * A shadow-DOM drop-down panel built on the shared terminal core. Mounted and
+ * toggled by the summoner via the reflected `open` attribute.
+ */
+@customElement("terminal-overlay")
+export class TerminalOverlay extends LitElement {
+
+  @property({ type: Boolean, reflect: true }) open = false;
+
+  // Critical layout lives here (synchronous) because the overlay mounts already
+  // open on first summon, before the async shadow-Tailwind fetch resolves.
+  static styles = css`
+    :host { display: contents; }
+
+    /* Rendered in the top layer via the Popover API so it paints above the
+       page regardless of ancestor stacking contexts (body has will-change).
+       These also override the UA popover defaults (centering, border, padding). */
+    #overlay-panel {
+      position: fixed;
+      inset: 0 0 auto 0;
+      margin: 0;
+      width: auto;
+      max-width: none;
+      height: 45vh;
+      max-height: 45vh;
+      padding: 0;
+      border: 0;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+      display: block;
+      transform: translateY(-100%);
+      color: #e8e6e3;
+      box-shadow: 0 12px 40px rgba(0, 0, 0, 0.45);
+      font-family: ui-monospace, "IBM Plex Mono", monospace;
+    }
+
+    /* A real painted fill rather than a CSS background on the popover element:
+       a top-layer popover only reliably paints its background where there is
+       content, leaving empty areas transparent. This div always paints. */
+    #overlay-bg {
+      position: absolute;
+      inset: 0;
+      z-index: 0;
+      background: rgba(20, 18, 24, 0.96);
+    }
+
+    #overlay-inner {
+      position: relative;
+      z-index: 1;
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+    }
+
+    @media (max-width: 768px) {
+      #overlay-panel { height: 60vh; max-height: 60vh; }
+    }
+
+    #overlay-log {
+      margin: 0;
+      flex: 1 1 auto;
+      overflow: auto;
+      padding: 1rem 1.25rem;
+      white-space: pre-wrap;
+      font-size: 0.85rem;
+      line-height: 1.5;
+    }
+
+    #overlay-form {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      border-top: 1px solid rgba(255, 255, 255, 0.12);
+      padding: 0.6rem 1.25rem;
+    }
+
+    #overlay-form::before {
+      content: "$";
+      opacity: 0.6;
+    }
+
+    #overlay-input {
+      flex: 1 1 auto;
+      background: transparent;
+      border: 0;
+      color: inherit;
+      font: inherit;
+      resize: none;
+      outline: none;
+    }
+
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
+  `;
+
+  @query("#overlay-panel") private _panel!: HTMLElement;
+  @query("#overlay-log") private _log!: HTMLElement;
+  @query("#overlay-input") private _input!: HTMLTextAreaElement;
+  @query("#overlay-form") private _form!: HTMLFormElement;
+
+  private _restoreFocusTo: Element | null = null;
+  private _skipAnimations =
+    window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches ?? false;
+
+  private _core = new TerminalCore({
+    commands: {
+      help: async (ctx: ParsedCommand) => {
+        await this._core.append(ctx.raw, 0.2, CommandType.command);
+        await this._core.append(
+          "help - list commands\nmore commands coming soon",
+          0.3,
+          CommandType.logdata
+        );
+      },
+    },
+    logEl: () => this._log,
+    skipAnimations: () => this._skipAnimations,
+    onLineWritten: () => this._scrollToBottom(),
+  });
+
+  async firstUpdated() {
+    try {
+      await adoptTailwind(this.renderRoot as ShadowRoot, "terminal-overlay-shadow.css");
+    } catch (e) {
+      console.error("[TerminalOverlay] Failed to load styles", e);
+    }
+  }
+
+  protected updated(changed: PropertyValues): void {
+    if (changed.has("open")) {
+      if (this.open) {
+        this._onOpened();
+      } else {
+        this._onClosed(changed.get("open") as boolean | undefined);
+      }
+    }
+  }
+
+  /**
+   * Focuses the input and slides the panel in when the overlay opens.
+   *
+   * @returns `void`.
+   */
+  private _onOpened(): void {
+    this._showPopover();
+    this._restoreFocusTo = document.activeElement;
+    this._input?.focus();
+    void this._slide(true);
+  }
+
+  /**
+   * Slides the panel out and restores focus when the overlay closes.
+   *
+   * @param wasOpen - Whether the overlay was previously open (skips work on first render).
+   * @returns `void`.
+   */
+  private _onClosed(wasOpen: boolean | undefined): void {
+    if (!wasOpen) return;
+
+    const restore = this._restoreFocusTo;
+    this._restoreFocusTo = null;
+
+    // Slide out, then leave the top layer; restore focus immediately.
+    void this._slide(false).then(() => this._hidePopover());
+
+    if (restore instanceof HTMLElement) {
+      restore.focus();
+    }
+  }
+
+  /** Promotes the panel into the top layer (no-op where unsupported). */
+  private _showPopover(): void {
+    try {
+      (this._panel as unknown as { showPopover?: () => void })?.showPopover?.();
+    } catch {
+      // already shown or popover unsupported — safe to ignore
+    }
+  }
+
+  /** Removes the panel from the top layer (no-op where unsupported). */
+  private _hidePopover(): void {
+    try {
+      (this._panel as unknown as { hidePopover?: () => void })?.hidePopover?.();
+    } catch {
+      // already hidden or popover unsupported — safe to ignore
+    }
+  }
+
+  /**
+   * Animates the panel drop-down; reduced motion is handled by the animator.
+   *
+   * @param show - Whether the panel is sliding into view.
+   * @returns `void`.
+   */
+  private _slide(show: boolean): Promise<void> {
+    if (!this._panel) return Promise.resolve();
+    animator.cancel(this._panel);
+    const keyframes = show
+      ? [{ transform: "translateY(-100%)" }, { transform: "translateY(0)" }]
+      : [{ transform: "translateY(0)" }, { transform: "translateY(-100%)" }];
+    return animator.animate(this._panel, keyframes, {
+      duration: 320,
+      easing: "cubic-bezier(.37,.79,.14,.93)",
+      fill: "both",
+    });
+  }
+
+  /**
+   * Handles panel-level keys: Escape closes; Enter (without Shift) submits.
+   *
+   * @param e - The keydown event from the panel or its input.
+   * @returns `void`.
+   */
+  private _onKeydown(e: KeyboardEvent): void {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      this.open = false;
+      return;
+    }
+
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      this._form?.requestSubmit();
+    }
+  }
+
+  /**
+   * Runs the submitted command line through the terminal core.
+   *
+   * @param e - The form submit event.
+   * @returns A promise that settles when the command finishes.
+   */
+  private async _onSubmit(e: Event): Promise<void> {
+    e.preventDefault();
+    const raw = this._input?.value ?? "";
+    this._input.value = "";
+    await this._core.run(raw);
+  }
+
+  /** Keeps the log scrolled to the latest line. */
+  private _scrollToBottom(): void {
+    if (this._log) this._log.scrollTop = this._log.scrollHeight;
+  }
+
+  protected render(): unknown {
+    return html`
+      <section
+        id="overlay-panel"
+        popover="manual"
+        role="dialog"
+        aria-label="Terminal"
+        @keydown=${this._onKeydown}
+      >
+        <div id="overlay-bg" aria-hidden="true"></div>
+        <div id="overlay-inner">
+          <pre id="overlay-log"></pre>
+          <form id="overlay-form" @submit=${this._onSubmit}>
+            <label class="sr-only" for="overlay-input">Terminal command</label>
+            <textarea
+              id="overlay-input"
+              name="command"
+              rows="1"
+              spellcheck="false"
+              autocomplete="off"
+            ></textarea>
+          </form>
+        </div>
+      </section>
+    `;
+  }
+}

--- a/v2-blog/src/components/terminal-summoner.ts
+++ b/v2-blog/src/components/terminal-summoner.ts
@@ -1,0 +1,5 @@
+import { createSummoner } from "../_helpers/terminal/summon.ts";
+
+// Eager, tiny entry script loaded on every base-layout page. The heavy overlay
+// bundle is lazy-loaded by the summoner only on the first Ctrl/Cmd+Shift+C.
+createSummoner(window);

--- a/v2-blog/tests/e2e/terminal-overlay.spec.ts
+++ b/v2-blog/tests/e2e/terminal-overlay.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "@playwright/test";
+
+test("Ctrl+Shift+C summons the overlay, runs help, and Esc closes it", async ({ page }) => {
+  await page.goto("/");
+
+  // Not present until summoned (lazy-loaded).
+  await expect(page.locator("terminal-overlay")).toHaveCount(0);
+
+  await page.keyboard.press("Control+Shift+C");
+
+  const overlay = page.locator("terminal-overlay");
+  await expect(overlay).toHaveAttribute("open", "");
+  await expect(page.getByRole("dialog", { name: "Terminal" })).toBeVisible();
+
+  // Input is focused on open; type help and run it.
+  const input = page.locator("#overlay-input");
+  await expect(input).toBeFocused();
+  await input.fill("help");
+  await page.keyboard.press("Enter");
+
+  await expect(page.locator("#overlay-log")).toContainText("help - list commands");
+
+  // Esc closes.
+  await page.keyboard.press("Escape");
+  await expect(overlay).not.toHaveAttribute("open", "");
+});
+
+test("the overlay is not summonable on the books terminal page", async ({ page }) => {
+  await page.goto("/books/");
+  await page.keyboard.press("Control+Shift+C");
+  await expect(page.locator("terminal-overlay")).toHaveCount(0);
+});

--- a/v2-blog/tests/unit/components/terminal-overlay.test.ts
+++ b/v2-blog/tests/unit/components/terminal-overlay.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { animatorMock, gsapMock } = vi.hoisted(() => ({
+  animatorMock: {
+    cancel: vi.fn(),
+    animate: vi.fn(() => Promise.resolve()),
+  },
+  gsapMock: {
+    to: vi.fn((_t, o?: { onUpdate?: () => void; onComplete?: () => void }) => {
+      o?.onUpdate?.();
+      o?.onComplete?.();
+      return {};
+    }),
+  },
+}));
+
+vi.mock("gsap", () => ({ gsap: gsapMock }));
+vi.mock("../../../src/_helpers/styleLoader.ts", () => ({
+  adoptTailwind: () => Promise.resolve(),
+}));
+vi.mock("../../../src/_helpers/animationManager.ts", () => ({
+  animator: animatorMock,
+}));
+
+import { TerminalOverlay } from "../../../src/components/terminal-overlay.ts";
+
+async function mountOverlay() {
+  const el = new TerminalOverlay();
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+function submit(el: TerminalOverlay, value: string) {
+  const input = el.shadowRoot!.querySelector<HTMLTextAreaElement>("#overlay-input")!;
+  input.value = value;
+  const form = el.shadowRoot!.querySelector<HTMLFormElement>("#overlay-form")!;
+  form.requestSubmit();
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  animatorMock.cancel.mockClear();
+  animatorMock.animate.mockClear();
+});
+
+describe("terminal-overlay", () => {
+  it("exposes a dialog and moves focus to the input when opened", async () => {
+    const el = await mountOverlay();
+
+    el.open = true;
+    await el.updateComplete;
+
+    const dialog = el.shadowRoot!.querySelector('[role="dialog"]');
+    expect(dialog).not.toBeNull();
+    expect(el.shadowRoot!.activeElement).toBe(el.shadowRoot!.querySelector("#overlay-input"));
+  });
+
+  it("runs the help command and appends output to the log", async () => {
+    const el = await mountOverlay();
+    el.open = true;
+    await el.updateComplete;
+
+    submit(el, "help");
+    await el.updateComplete;
+    await Promise.resolve();
+
+    const log = el.shadowRoot!.querySelector("#overlay-log")!;
+    expect(log.textContent).toContain("help - list commands");
+  });
+
+  it("submits the command when Enter is pressed in the input", async () => {
+    const el = await mountOverlay();
+    el.open = true;
+    await el.updateComplete;
+
+    const input = el.shadowRoot!.querySelector<HTMLTextAreaElement>("#overlay-input")!;
+    input.value = "help";
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    await el.updateComplete;
+    await Promise.resolve();
+
+    expect(el.shadowRoot!.querySelector("#overlay-log")!.textContent).toContain("help - list commands");
+    expect(input.value).toBe("");
+  });
+
+  it("inserts a newline (does not submit) on Shift+Enter", async () => {
+    const el = await mountOverlay();
+    el.open = true;
+    await el.updateComplete;
+
+    const input = el.shadowRoot!.querySelector<HTMLTextAreaElement>("#overlay-input")!;
+    input.value = "hel";
+    const event = new KeyboardEvent("keydown", { key: "Enter", shiftKey: true, bubbles: true, cancelable: true });
+    input.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("closes when Escape is pressed", async () => {
+    const el = await mountOverlay();
+    el.open = true;
+    await el.updateComplete;
+
+    const panel = el.shadowRoot!.querySelector("#overlay-panel")!;
+    panel.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    await el.updateComplete;
+
+    expect(el.open).toBe(false);
+  });
+
+  it("restores focus to the previously focused element on close", async () => {
+    const trigger = document.createElement("button");
+    document.body.appendChild(trigger);
+    trigger.focus();
+
+    const el = await mountOverlay();
+    el.open = true;
+    await el.updateComplete;
+    el.open = false;
+    await el.updateComplete;
+
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("slides the panel in via the animator on open", async () => {
+    const el = await mountOverlay();
+    el.open = true;
+    await el.updateComplete;
+
+    expect(animatorMock.animate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/v2-blog/tests/unit/helpers/terminal/summon.test.ts
+++ b/v2-blog/tests/unit/helpers/terminal/summon.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { matchesSummonCombo } from "../../../../src/_helpers/terminal/summon.ts";
+
+/**
+ * Builds a minimal keydown-like object for predicate testing.
+ */
+function key(overrides: Partial<KeyboardEvent>): KeyboardEvent {
+  return {
+    ctrlKey: false,
+    metaKey: false,
+    shiftKey: false,
+    altKey: false,
+    code: "",
+    ...overrides,
+  } as KeyboardEvent;
+}
+
+describe("matchesSummonCombo", () => {
+  it("matches Ctrl+Shift+C", () => {
+    expect(matchesSummonCombo(key({ ctrlKey: true, shiftKey: true, code: "KeyC" }))).toBe(true);
+  });
+
+  it("matches Cmd+Shift+C (macOS)", () => {
+    expect(matchesSummonCombo(key({ metaKey: true, shiftKey: true, code: "KeyC" }))).toBe(true);
+  });
+
+  it("ignores layout-dependent key casing by matching on code", () => {
+    // On some layouts the produced character is "c", on others "C"; both must match.
+    expect(matchesSummonCombo(key({ ctrlKey: true, shiftKey: true, code: "KeyC", key: "c" }))).toBe(true);
+    expect(matchesSummonCombo(key({ ctrlKey: true, shiftKey: true, code: "KeyC", key: "C" }))).toBe(true);
+  });
+
+  it("requires Shift", () => {
+    expect(matchesSummonCombo(key({ ctrlKey: true, code: "KeyC" }))).toBe(false);
+  });
+
+  it("requires a Ctrl or Cmd modifier", () => {
+    expect(matchesSummonCombo(key({ shiftKey: true, code: "KeyC" }))).toBe(false);
+  });
+
+  it("requires the C key specifically", () => {
+    expect(matchesSummonCombo(key({ ctrlKey: true, shiftKey: true, code: "KeyX" }))).toBe(false);
+  });
+});

--- a/v2-blog/tests/unit/helpers/terminal/summoner.test.ts
+++ b/v2-blog/tests/unit/helpers/terminal/summoner.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createSummoner } from "../../../../src/_helpers/terminal/summon.ts";
+
+let dispose: (() => void) | undefined;
+
+function pressCombo(overrides: Partial<KeyboardEvent> = {}) {
+  const event = new KeyboardEvent("keydown", {
+    ctrlKey: true,
+    shiftKey: true,
+    cancelable: true,
+    bubbles: true,
+    ...overrides,
+  });
+  // jsdom KeyboardEvent ignores `code` from init in some versions; force it.
+  Object.defineProperty(event, "code", { value: overrides.code ?? "KeyC" });
+  window.dispatchEvent(event);
+  return event;
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  document.head.querySelectorAll("script").forEach((s) => s.remove());
+});
+
+afterEach(() => {
+  dispose?.();
+  dispose = undefined;
+});
+
+describe("createSummoner", () => {
+  it("opens a terminal-overlay element when the summon combo is pressed", () => {
+    dispose = createSummoner(window);
+
+    pressCombo();
+
+    const overlay = document.querySelector("terminal-overlay");
+    expect(overlay).not.toBeNull();
+    expect(overlay?.hasAttribute("open")).toBe(true);
+  });
+
+  it("never calls preventDefault on the combo (DevTools must still open)", () => {
+    dispose = createSummoner(window);
+
+    const event = pressCombo();
+
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("lazy-loads the overlay bundle exactly once across repeated summons", () => {
+    dispose = createSummoner(window);
+
+    pressCombo();
+    pressCombo();
+
+    const scripts = document.head.querySelectorAll('script[src="/components/terminal-overlay.js"]');
+    const overlays = document.querySelectorAll("terminal-overlay");
+    expect(scripts).toHaveLength(1);
+    expect(overlays).toHaveLength(1);
+  });
+
+  it("ignores non-matching keys", () => {
+    dispose = createSummoner(window);
+
+    pressCombo({ code: "KeyX" });
+
+    expect(document.querySelector("terminal-overlay")).toBeNull();
+    expect(document.head.querySelector('script[src="/components/terminal-overlay.js"]')).toBeNull();
+  });
+
+  it("stops responding after the disposer runs", () => {
+    const localDispose = createSummoner(window);
+    localDispose();
+
+    pressCombo();
+
+    expect(document.querySelector("terminal-overlay")).toBeNull();
+  });
+});


### PR DESCRIPTION
Part of #77 (overlay skeleton slice of the cheat-console epic #76–#82).

## What this delivers

`Ctrl/Cmd+Shift+C` summons a top drop-down terminal console on every base-layout page (home, posts, notes, about). The books page keeps its own full-page terminal and is intentionally excluded.

- **Summoner** (`terminal-summoner.ts`, 474 B, no Lit): capture-phase keydown, **never** `preventDefault` — on Windows/Linux DevTools opens alongside the terminal (the spike-verified "both consoles" behavior). Lazily injects the overlay bundle on first press, so content pages pay almost nothing until summoned.
- **Overlay** (`terminal-overlay.ts`): shadow-DOM Lit element on the shared `TerminalCore` (`help` command for this slice). `role="dialog"`, focus moves to the input on open, **Esc closes and restores focus**, slide-in uses the reduced-motion-aware `animator`.
- **Shadow CSS** wired through the existing Tailwind pipeline (new `terminal-overlay-shadow.css` target in `eleventy.config.ts`).
- CSP unchanged — the summoner is an external `'self'` module, no new inline hashes.

## Notable implementation detail

The overlay renders in the **top layer** via the Popover API. `body` participates in compositing (`will-change`/view-transitions), which would otherwise let page content paint over a plain `z-index` fixed panel. Two top-layer quirks were worked around: the popover element is `display:block` (a flex top-layer element mis-paints), and the dark background is a painted fill `<div>` rather than a CSS `background` (a top-layer popover only reliably paints background where there's content).

## Tests

- Unit: `matchesSummonCombo` (combo/ layout independence), `createSummoner` (lazy-load once, no preventDefault, disposer), overlay (open/focus, help output, **Enter-to-submit** — caught by the e2e first, then locked), Esc-close, focus restore, slide. 77 unit tests green.
- e2e: summon → help → Esc; plus books-page-exclusion. Typecheck + lint clean; production build green.

## Not in this slice / follow-ups

- Visual smoke done at desktop width; mobile 60vh is a CSS media query (unscreenshotted). Real-Windows verification of the coexist behavior is tracked in the #82 gate.
- Navigation commands, unlock button, sound/boot are later slices (#78, #80, #81).