### PR TITLE
refactor(terminal): drive terminal-shell from a single state reducer

### DIFF
--- a/v2-blog/src/_helpers/terminal/shell-state.ts
+++ b/v2-blog/src/_helpers/terminal/shell-state.ts
@@ -1,0 +1,104 @@
+/** Which view the books terminal is in: a listing of books or a single book. */
+export type RouteMode = "listing" | "detail";
+
+/**
+ * Single source of truth for the books terminal's internal view and lifecycle
+ * state. Replaces the previously scattered reactive flags (see ADR-0001).
+ */
+export interface ShellState {
+  routeMode: RouteMode;
+  isMobile: boolean;
+  sidebarOpen: boolean;
+  booted: boolean;
+  focused: boolean;
+  bootStarted: boolean;
+  interactionReady: boolean;
+  bookDataLoaded: boolean;
+  skipAnimations: boolean;
+  isTyping: boolean;
+  command: string;
+  booksDisplayed: number;
+}
+
+/** All state transitions the books terminal can perform. */
+export type ShellAction =
+  | { type: "INITIALIZED"; routeMode: RouteMode }
+  | { type: "VIEWPORT_CHANGED"; isMobile: boolean }
+  | { type: "SIDEBAR_SET"; open: boolean }
+  | { type: "BOOTED" }
+  | { type: "BOOT_STARTED" }
+  | { type: "INTERACTION_READY" }
+  | { type: "BOOK_DATA_LOADED" }
+  | { type: "INPUT_CHANGED"; value: string }
+  | { type: "TYPING_SET"; typing: boolean }
+  | { type: "FOCUS_SET"; focused: boolean }
+  | { type: "ANIMATIONS_TOGGLED" }
+  | { type: "BOOKS_ADVANCED"; count: number };
+
+/**
+ * Builds the initial shell state. Environment-derived defaults (viewport,
+ * reduced-motion) are injected by the caller so the reducer stays pure.
+ *
+ * @param opts - Optional initial `isMobile` / `skipAnimations` values.
+ * @returns A fresh `ShellState`.
+ */
+export function createInitialShellState(
+  opts: { isMobile?: boolean; skipAnimations?: boolean } = {}
+): ShellState {
+  return {
+    routeMode: "detail",
+    isMobile: opts.isMobile ?? false,
+    sidebarOpen: false,
+    booted: false,
+    focused: false,
+    bootStarted: false,
+    interactionReady: false,
+    bookDataLoaded: false,
+    skipAnimations: opts.skipAnimations ?? false,
+    isTyping: false,
+    command: "",
+    booksDisplayed: 0,
+  };
+}
+
+/**
+ * Pure reducer: derives the next shell state from the current state and an action.
+ *
+ * @param state - The current state.
+ * @param action - The transition to apply.
+ * @returns The next state (a new object; `state` is never mutated).
+ */
+export function shellReducer(state: ShellState, action: ShellAction): ShellState {
+  switch (action.type) {
+    case "INITIALIZED":
+      return { ...state, routeMode: action.routeMode };
+    case "VIEWPORT_CHANGED":
+      return {
+        ...state,
+        isMobile: action.isMobile,
+        sidebarOpen: action.isMobile ? state.sidebarOpen : false,
+      };
+    case "SIDEBAR_SET":
+      return { ...state, sidebarOpen: action.open };
+    case "BOOTED":
+      return { ...state, booted: true, focused: true };
+    case "BOOT_STARTED":
+      return { ...state, bootStarted: true };
+    case "INTERACTION_READY":
+      return { ...state, interactionReady: true };
+    case "BOOK_DATA_LOADED":
+      return { ...state, bookDataLoaded: true };
+    case "INPUT_CHANGED":
+      return { ...state, command: action.value };
+    case "TYPING_SET":
+      return { ...state, isTyping: action.typing };
+    case "FOCUS_SET":
+      return { ...state, focused: action.focused };
+    case "ANIMATIONS_TOGGLED":
+      return { ...state, skipAnimations: !state.skipAnimations };
+    case "BOOKS_ADVANCED":
+      return { ...state, booksDisplayed: state.booksDisplayed + action.count };
+    default:
+      return state;
+  }
+}

--- a/v2-blog/src/components/terminal-shell.ts
+++ b/v2-blog/src/components/terminal-shell.ts
@@ -4,8 +4,12 @@ import { gsap } from 'gsap';
 import { IdentityManager, IDMode } from '../_helpers/identityManager.ts';
 import { CommandType, TerminalCore } from '../_helpers/terminal/core.ts';
 import type { ParsedCommand } from '../_helpers/terminal/parser.ts';
-
-type RouteMode = "listing" | "detail";
+import {
+  createInitialShellState,
+  shellReducer,
+  type ShellAction,
+  type ShellState,
+} from '../_helpers/terminal/shell-state.ts';
 
 @customElement('terminal-shell')
 export class TerminalShell extends LitElement {
@@ -14,9 +18,6 @@ export class TerminalShell extends LitElement {
     return this;
   }
 
-  @property({ type: Boolean }) booted = false;
-  @property({ type: Boolean }) sidebarOpen = false;
-  @property({ type: Boolean }) isMobile = window.innerWidth <= 768;
   @property({ type: Boolean }) quickActionsExecute = false;
   @property({ type: String, reflect: true })
   userID: string = "";
@@ -30,10 +31,6 @@ export class TerminalShell extends LitElement {
   private hasUserName = this.identity.getCachedName();
   private _resizeObs?: ResizeObserver;
   private _typingTimer?: number;
-  private _routeMode: RouteMode = "detail";
-  private _bootSequenceStarted = false;
-  private _interactionReady = false;
-  private _bookDataLoaded = false;
   private _startupRafOne?: number;
   private _startupRafTwo?: number;
   private _asciiRenderRaf?: number;
@@ -53,14 +50,23 @@ export class TerminalShell extends LitElement {
   // @query('#terminal-text') private _textAreaCLI!: HTMLDivElement;
 
 
-  @state() private booksDisplayed = 0;
-  @state() private readonly batchSize = 3;
-  @state() private commandCLI = "";
-  @state() private focused = false;
-  @state() private isTyping = false;
-  @state() private labelVar = '--label-width';
-  @state() private _skipAnimations =
-    window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches ?? false;
+  private readonly batchSize = 3;
+  private readonly labelVar = '--label-width';
+
+  @state() private shell: ShellState = createInitialShellState({
+    isMobile: window.innerWidth <= 768,
+    skipAnimations: window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches ?? false,
+  });
+
+  /**
+   * Applies a state transition through the pure shell reducer.
+   *
+   * @param action - The transition to apply.
+   * @returns `void`.
+   */
+  private dispatch(action: ShellAction): void {
+    this.shell = shellReducer(this.shell, action);
+  }
 
   private readonly COMMANDS: Record<
     string,
@@ -69,9 +75,9 @@ export class TerminalShell extends LitElement {
       help: async (ctx) => {
         await this.appendToLog(`${ctx.raw}`, 0.2, CommandType.command);
 
-        if (this.isMobile) {
+        if (this.shell.isMobile) {
           this._inputCLI?.blur();
-          this.sidebarOpen = true;
+          this.dispatch({ type: "SIDEBAR_SET", open: true });
         } else {
           await this.appendToLog("commands", 0.2, CommandType.title);
           await this.appendToLog(
@@ -93,7 +99,7 @@ export class TerminalShell extends LitElement {
         }
 
         // const art = typeof ctx.flags.art === "string" ? this._sanitizeArtId(ctx.flags.art) : undefined;
-        if (this.isMobile) { this._inputCLI?.blur(); this.sidebarOpen = false };
+        if (this.shell.isMobile) { this._inputCLI?.blur(); this.dispatch({ type: "SIDEBAR_SET", open: false }); };
         this.appendToLog(`${ctx.raw}`, 0, CommandType.command);
 
         await this.displayNextBatch();
@@ -117,13 +123,13 @@ export class TerminalShell extends LitElement {
       },
 
       skip: async (ctx) => {
-        if (this.isMobile) {
+        if (this.shell.isMobile) {
           this._inputCLI?.blur();
-          this.sidebarOpen = false;
+          this.dispatch({ type: "SIDEBAR_SET", open: false });
         }
         if (ctx.positionals[0] === "animations") {
           await this.appendToLog(`${ctx.raw} ${ctx.positionals[0]}`, 0.2, CommandType.command);
-          await this.appendToLog(`  animations turned ${this._skipAnimations ? "on" : "off"}`, 0.2, CommandType.log);
+          await this.appendToLog(`  animations turned ${this.shell.skipAnimations ? "on" : "off"}`, 0.2, CommandType.log);
           this._toggleSkipAnim();
         } else {
           await this.appendToLog(ctx.raw, 0.2, CommandType.command);
@@ -175,7 +181,7 @@ export class TerminalShell extends LitElement {
   private _core = new TerminalCore({
     commands: this.COMMANDS,
     logEl: () => this.querySelector("#boot-log"),
-    skipAnimations: () => this._skipAnimations,
+    skipAnimations: () => this.shell.skipAnimations,
     onLineWritten: () => this._scrollToBottom(this._outputCLI),
   });
 
@@ -186,10 +192,16 @@ export class TerminalShell extends LitElement {
   }
 
   protected updated(changed: Map<string, unknown>) {
-    if (changed.has("isMobile") && !this.isMobile) {
-      this.sidebarOpen = false;
-    }
-    if (changed.has("commandCLI") || changed.has("focused") || changed.has("isMobile")) {
+    if (!changed.has("shell")) return;
+    // Reposition the fake caret when the inputs that affect its position change.
+    // (The "close sidebar on desktop" rule now lives in the reducer.)
+    const prev = changed.get("shell") as ShellState | undefined;
+    if (
+      !prev ||
+      prev.command !== this.shell.command ||
+      prev.focused !== this.shell.focused ||
+      prev.isMobile !== this.shell.isMobile
+    ) {
       requestAnimationFrame(() => this._updateFakeCaretPosition());
     }
   }
@@ -236,7 +248,7 @@ export class TerminalShell extends LitElement {
    * @returns `void`.
    */
   private _runRequiredOnLoadStartup() {
-    this._routeMode = this._dataScript ? "listing" : "detail";
+    this.dispatch({ type: "INITIALIZED", routeMode: this._dataScript ? "listing" : "detail" });
     this.userID = this.hasUserName || this._fallbackUserId;
     this._syncPromptWidth();
   }
@@ -247,7 +259,7 @@ export class TerminalShell extends LitElement {
    * @returns `void`.
    */
   private _schedulePostPaintStartup() {
-    if (this._bootSequenceStarted) return;
+    if (this.shell.bootStarted) return;
 
     this._startupRafOne = requestAnimationFrame(() => {
       this._startupRafOne = undefined;
@@ -264,9 +276,9 @@ export class TerminalShell extends LitElement {
    * @returns A promise that settles when boot initialization is done.
    */
   private async _runPostPaintStartup() {
-    if (!this.isConnected || this._bootSequenceStarted) return;
+    if (!this.isConnected || this.shell.bootStarted) return;
 
-    this._bootSequenceStarted = true;
+    this.dispatch({ type: "BOOT_STARTED" });
     await this.startBootSequence();
   }
 
@@ -276,9 +288,9 @@ export class TerminalShell extends LitElement {
    * @returns `void`.
    */
   private _ensureInteractionStartup() {
-    if (this._interactionReady) return;
+    if (this.shell.interactionReady) return;
 
-    this._interactionReady = true;
+    this.dispatch({ type: "INTERACTION_READY" });
     this._ensureIdentityReady();
     this._ensureCaretObserver();
   }
@@ -317,11 +329,11 @@ export class TerminalShell extends LitElement {
    * @returns `void`.
    */
   private _ensureBookDataLoaded() {
-    if (this._bookDataLoaded || !this._dataScript) return;
+    if (this.shell.bookDataLoaded || !this._dataScript) return;
 
     this.bookData = this._parseBookDataPayload(this._dataScript.textContent);
     this._dataScript.remove();
-    this._bookDataLoaded = true;
+    this.dispatch({ type: "BOOK_DATA_LOADED" });
   }
 
   /**
@@ -393,7 +405,7 @@ export class TerminalShell extends LitElement {
         await this._deferNonCriticalTask();
         if (!this.isConnected || !this._asciiArea) return;
 
-        if (this._skipAnimations) {
+        if (this.shell.skipAnimations) {
           await this._renderAsciiForBookInstant(id);
           return;
         }
@@ -422,14 +434,13 @@ export class TerminalShell extends LitElement {
       CommandType.log
     );
 
-    if (this._routeMode === "detail") {
+    if (this.shell.routeMode === "detail") {
       await this.handleDirectAccessReveal();
     } else {
       await this.appendToLog("TYPE 'HELP' FOR COMMANDS.", 0, CommandType.log);
     }
 
-    this.booted = true;
-    this.focused = true;
+    this.dispatch({ type: "BOOTED" });
     requestAnimationFrame(() => {
       this._inputCLI?.focus();
     });
@@ -452,7 +463,7 @@ export class TerminalShell extends LitElement {
     const el = e.target as HTMLTextAreaElement;
     var val = el.value;
     // this._textCLI.textContent = val;
-    this.commandCLI = val
+    this.dispatch({ type: "INPUT_CHANGED", value: val });
 
     el.style.height = 'auto';
     el.style.height = el.scrollHeight + 'px';
@@ -465,7 +476,7 @@ export class TerminalShell extends LitElement {
     if (!el) return;
 
     el.value = next;
-    this.commandCLI = next;
+    this.dispatch({ type: "INPUT_CHANGED", value: next });
 
     el.style.height = "auto";
     el.style.height = el.scrollHeight + "px";
@@ -528,7 +539,7 @@ export class TerminalShell extends LitElement {
     if (e.key.length === 1) {
       return;
     }
-    this.isTyping = true;
+    this.dispatch({ type: "TYPING_SET", typing: true });
     e.preventDefault();
   }
 
@@ -546,7 +557,7 @@ export class TerminalShell extends LitElement {
     if (value === undefined) return;
 
     this._inputCLI.value = value;
-    this.commandCLI = value;
+    this.dispatch({ type: "INPUT_CHANGED", value });
   }
 
   /**
@@ -645,7 +656,7 @@ export class TerminalShell extends LitElement {
    */
   private async displayNextBatch() {
     this._ensureBookDataLoaded();
-    const batch = this.bookData.slice(this.booksDisplayed, this.booksDisplayed + this.batchSize);
+    const batch = this.bookData.slice(this.shell.booksDisplayed, this.shell.booksDisplayed + this.batchSize);
 
     if (batch.length === 0) {
       await this.appendToLog("Bookshelf scan complete.", 0.2, CommandType.log);
@@ -654,18 +665,18 @@ export class TerminalShell extends LitElement {
     }
 
     for (const book of batch) {
-      const artId = this.booksDisplayed + 1;
+      const artId = this.shell.booksDisplayed + 1;
       this._queueAsciiRenderForBook(artId);
 
       await this.appendToLog(`\n[${book.id}] ${book.title}`, 0.15, CommandType.logdata);
       await this.appendToLog(`      ${book.author}`, 0.15, CommandType.logdata);
 
-      this.booksDisplayed++;
+      this.dispatch({ type: "BOOKS_ADVANCED", count: 1 });
       this._scrollToBottom(this._outputCLI);
     }
 
-    if (this.bookData.length - this.booksDisplayed) {
-      await this.appendToLog(`books remaining: ${this.bookData.length - this.booksDisplayed}`, 0, CommandType.status);
+    if (this.bookData.length - this.shell.booksDisplayed) {
+      await this.appendToLog(`books remaining: ${this.bookData.length - this.shell.booksDisplayed}`, 0, CommandType.status);
     } else {
       await this.appendToLog("bookshelf scan complete.", 0.2, CommandType.status);
     }
@@ -679,7 +690,7 @@ export class TerminalShell extends LitElement {
     const raw = String(new FormData(form).get("command") ?? "");
 
     form.reset();
-    this.commandCLI = "";
+    this.dispatch({ type: "INPUT_CHANGED", value: "" });
     this._scrollToBottom(this._outputCLI);
 
     await this._executeCommand(raw);
@@ -697,7 +708,7 @@ export class TerminalShell extends LitElement {
   }
 
   private _insertCommand(cmd: string, mode: "replace" | "append" = "replace") {
-    const current = (this.commandCLI ?? "").trim();
+    const current = (this.shell.command ?? "").trim();
 
     const next =
       mode === "append" && current.length > 0
@@ -710,7 +721,7 @@ export class TerminalShell extends LitElement {
   private async _runCommand(cmd: string) {
     this._setTextareaValue(cmd, { focus: false, placeCaretAtEnd: true });
 
-    this.commandCLI = "";
+    this.dispatch({ type: "INPUT_CHANGED", value: "" });
     const el = this._inputCLI as HTMLTextAreaElement | null;
     if (el) {
       el.value = "";
@@ -722,7 +733,7 @@ export class TerminalShell extends LitElement {
   }
 
   private _onQuickAction(cmd: string) {
-    if (this.sidebarOpen) { this.sidebarOpen = false }
+    if (this.shell.sidebarOpen) { this.dispatch({ type: "SIDEBAR_SET", open: false }); }
     if (cmd === "help") return this._runCommand("help");
     if (this.quickActionsExecute) return this._runCommand(cmd);
     this._insertCommand(cmd, "replace");
@@ -755,12 +766,12 @@ export class TerminalShell extends LitElement {
   private _preventMouseCaret(e: MouseEvent) {
     e.preventDefault();
 
-    if (!this.booted) return;
+    if (!this.shell.booted) return;
 
     this._ensureInteractionStartup();
     const el = this._inputCLI; //e.currentTarget as HTMLTextAreaElement;
     el.focus();
-    this.focused = true;
+    this.dispatch({ type: "FOCUS_SET", focused: true });
 
     const end = el.value.length;
     el.setSelectionRange(end, end);
@@ -780,12 +791,12 @@ export class TerminalShell extends LitElement {
   }
 
   private _handleBlur() {
-    this.focused = false;
+    this.dispatch({ type: "FOCUS_SET", focused: false });
     requestAnimationFrame(() => this._updateFakeCaretPosition());
   }
 
   private _toggleSkipAnim() {
-    this._skipAnimations = !this._skipAnimations
+    this.dispatch({ type: "ANIMATIONS_TOGGLED" });
   }
 
   private _updateFakeCaretPosition() {
@@ -806,30 +817,28 @@ export class TerminalShell extends LitElement {
   }
 
   private _onTyping() {
-    if (!this.isTyping) {
-      this.isTyping = true;
-      this.requestUpdate();
+    if (!this.shell.isTyping) {
+      this.dispatch({ type: "TYPING_SET", typing: true });
     }
 
     // reset debounce
     clearTimeout(this._typingTimer);
     this._typingTimer = window.setTimeout(() => {
-      this.isTyping = false;
-      this.requestUpdate();
+      this.dispatch({ type: "TYPING_SET", typing: false });
     }, 500);
   }
 
 
   protected render(): unknown {
-    const anim = this._skipAnimations;
+    const anim = this.shell.skipAnimations;
 
     return html`
-      ${this.isMobile ? html`
+      ${this.shell.isMobile ? html`
         <details
           id="terminal-sidebar"
-          class="${!this._skipAnimations ? "transition" : ""}"
-          ?open=${this.sidebarOpen}
-          @toggle=${(e: any) => { this.sidebarOpen = e.currentTarget.open; }}
+          class="${!this.shell.skipAnimations ? "transition" : ""}"
+          ?open=${this.shell.sidebarOpen}
+          @toggle=${(e: any) => this.dispatch({ type: "SIDEBAR_SET", open: e.currentTarget.open })}
           >
           <summary aria-label="Commands Options">
             <span aria-hidden="true" class="ico"></span>
@@ -869,13 +878,13 @@ export class TerminalShell extends LitElement {
               <span> - get a random book to be analized</span>
             </p>
           </div>
-          <button @click="${() => (this.sidebarOpen = false)}" type="button" class="btn mobile">close options</button>
+          <button @click="${() => this.dispatch({ type: "SIDEBAR_SET", open: false })}" type="button" class="btn mobile">close options</button>
         </details>`
         :
         nothing
       }
       <div id="terminal-cli">
-        <div class="helpers ${this.isMobile ? "hidden" : ""}">
+        <div class="helpers ${this.shell.isMobile ? "hidden" : ""}">
           <button
             id="skip" 
             type="button" 
@@ -889,7 +898,7 @@ export class TerminalShell extends LitElement {
         </div>
 
         <form id="terminal-form" @submit=${this._handleSubmit}>
-          <label id="user-label" for="terminal-input" class="prompt">${!this.isMobile ? this.userID + "@BOOK_OS:~$" : ">"}</label>
+          <label id="user-label" for="terminal-input" class="prompt">${!this.shell.isMobile ? this.userID + "@BOOK_OS:~$" : ">"}</label>
           <div id="input-wrap">
             <textarea
               id="terminal-input"
@@ -900,11 +909,11 @@ export class TerminalShell extends LitElement {
               @keydown=${this._handleInputKeys}
               @mousedown=${this._preventMouseCaret}
               @selection=${this._forceCaretRules}
-              ?disabled="${!this.booted}"
+              ?disabled="${!this.shell.booted}"
               spellcheck="false"></textarea>
             <div
-              class="${!this.isTyping ? "blink" : ""} ${!this.focused ? "invisible" : ""} ${this.isMobile ? "hidden" : ""}"
-              id="terminal-text"><span id="terminal-mirror">${this.commandCLI}</span><span id="caret-anchor">&#8203;</span><span id="fake-caret" aria-hidden="true"></span></div>
+              class="${!this.shell.isTyping ? "blink" : ""} ${!this.shell.focused ? "invisible" : ""} ${this.shell.isMobile ? "hidden" : ""}"
+              id="terminal-text"><span id="terminal-mirror">${this.shell.command}</span><span id="caret-anchor">&#8203;</span><span id="fake-caret" aria-hidden="true"></span></div>
           </div>
         </form>
       </div>

--- a/v2-blog/tests/unit/components/terminal-shell.test.ts
+++ b/v2-blog/tests/unit/components/terminal-shell.test.ts
@@ -161,9 +161,11 @@ describe("terminal-shell startup phases", () => {
     appendSpy.mockResolvedValue(undefined);
 
     await element.startBootSequence();
+    await element.updateComplete;
 
     expect(revealSpy).not.toHaveBeenCalled();
-    expect(element.booted).toBe(true);
+    // booted is now internal state; assert its observable effect: input is enabled.
+    expect(element.querySelector("#terminal-input")?.hasAttribute("disabled")).toBe(false);
     expect(appendSpy).toHaveBeenCalled();
   });
 

--- a/v2-blog/tests/unit/helpers/terminal/shell-state.test.ts
+++ b/v2-blog/tests/unit/helpers/terminal/shell-state.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import { createInitialShellState, shellReducer } from "../../../../src/_helpers/terminal/shell-state.ts";
+
+describe("shellReducer", () => {
+  it("sets the route mode on INITIALIZED", () => {
+    const state = createInitialShellState();
+
+    const next = shellReducer(state, { type: "INITIALIZED", routeMode: "listing" });
+
+    expect(next.routeMode).toBe("listing");
+  });
+
+  it("forces the sidebar closed when switching to desktop, but leaves it on mobile", () => {
+    const open = { ...createInitialShellState(), isMobile: true, sidebarOpen: true };
+
+    const toDesktop = shellReducer(open, { type: "VIEWPORT_CHANGED", isMobile: false });
+    expect(toDesktop.isMobile).toBe(false);
+    expect(toDesktop.sidebarOpen).toBe(false);
+
+    const stayMobile = shellReducer(open, { type: "VIEWPORT_CHANGED", isMobile: true });
+    expect(stayMobile.sidebarOpen).toBe(true);
+  });
+
+  it("opens and closes the sidebar with SIDEBAR_SET", () => {
+    const state = createInitialShellState();
+
+    expect(shellReducer(state, { type: "SIDEBAR_SET", open: true }).sidebarOpen).toBe(true);
+    expect(shellReducer({ ...state, sidebarOpen: true }, { type: "SIDEBAR_SET", open: false }).sidebarOpen).toBe(false);
+  });
+
+  it("marks booted and focused together on BOOTED", () => {
+    const next = shellReducer(createInitialShellState(), { type: "BOOTED" });
+
+    expect(next.booted).toBe(true);
+    expect(next.focused).toBe(true);
+  });
+
+  it("flips the run-once lifecycle latches", () => {
+    const s = createInitialShellState();
+
+    expect(shellReducer(s, { type: "BOOT_STARTED" }).bootStarted).toBe(true);
+    expect(shellReducer(s, { type: "INTERACTION_READY" }).interactionReady).toBe(true);
+    expect(shellReducer(s, { type: "BOOK_DATA_LOADED" }).bookDataLoaded).toBe(true);
+  });
+
+  it("stores the current command text on INPUT_CHANGED", () => {
+    const next = shellReducer(createInitialShellState(), { type: "INPUT_CHANGED", value: "list --all" });
+    expect(next.command).toBe("list --all");
+  });
+
+  it("sets typing and focus flags", () => {
+    const s = createInitialShellState();
+    expect(shellReducer(s, { type: "TYPING_SET", typing: true }).isTyping).toBe(true);
+    expect(shellReducer({ ...s, focused: false }, { type: "FOCUS_SET", focused: true }).focused).toBe(true);
+  });
+
+  it("toggles skipAnimations", () => {
+    const s = createInitialShellState();
+    const on = shellReducer(s, { type: "ANIMATIONS_TOGGLED" });
+    expect(on.skipAnimations).toBe(!s.skipAnimations);
+    expect(shellReducer(on, { type: "ANIMATIONS_TOGGLED" }).skipAnimations).toBe(s.skipAnimations);
+  });
+
+  it("advances the books-displayed counter by a count", () => {
+    const s = { ...createInitialShellState(), booksDisplayed: 3 };
+    expect(shellReducer(s, { type: "BOOKS_ADVANCED", count: 3 }).booksDisplayed).toBe(6);
+  });
+
+  it("never mutates the input state and returns a new object", () => {
+    const s = createInitialShellState();
+    const frozen = Object.freeze({ ...s });
+
+    const next = shellReducer(frozen, { type: "BOOTED" });
+
+    expect(next).not.toBe(frozen);
+    expect(frozen.booted).toBe(false);
+  });
+
+  it("returns the same state reference for an unknown action", () => {
+    const s = createInitialShellState();
+    // @ts-expect-error — exercising the default branch with an unknown action
+    expect(shellReducer(s, { type: "NOPE" })).toBe(s);
+  });
+});


### PR DESCRIPTION
Closes #85. Implements ADR-0001 (state model).

## What changed

`terminal-shell`'s scattered reactive flags and lifecycle latches are consolidated into one immutable `ShellState`, updated through a pure `shellReducer(state, action)` in `src/_helpers/terminal/shell-state.ts` (shell-local but liftable).

- `render()` reads only from `this.shell`.
- A single `dispatch(action)` is the only path that changes state.
- Side effects (caret reposition) fire from Lit's `updated()` by diffing old vs new state — no Elm-style effect-runtime (per ADR-0001).
- The "close the sidebar when switching to desktop" rule moved out of `updated()` and into the reducer (`VIEWPORT_CHANGED`).
- `userID` (reflected identity) and `quickActionsExecute` (config) stay `@property`; `terminal-core` is untouched.

## Behavior

Pure refactor — the books page behaves identically.

## Tests

- 11 new reducer unit tests (TDD): each transition, the desktop/mobile viewport rule, immutability (input frozen, new object returned), and unknown-action passthrough.
- Full suite green: 88 unit tests, typecheck clean, lint 0 errors, production build green, Playwright e2e green.
- Real-browser books smoke: desktop boot → `list` batching → ArrowUp history recall → unknown-command error → book-detail reveal, plus the now-reducer-driven mobile sidebar (`help` opens it).

## Note

One existing test asserted the now-internal `booted` flag; it was updated to assert the observable effect (input becomes enabled after boot) rather than the private field.

Independent of #86 (linear-stream aesthetic).