### PR TITLE
feat(terminal): linear-stream aesthetic with theme-derived palette

### DIFF
--- a/v2-blog/src/_helpers/terminal/core.ts
+++ b/v2-blog/src/_helpers/terminal/core.ts
@@ -17,6 +17,26 @@ export enum CommandType {
 
 export type CommandHandler = (ctx: ParsedCommand) => Promise<void> | void;
 
+/**
+ * Maps a log line's kind to its short uppercase badge label.
+ * Shared by every terminal surface so badges stay consistent (see ADR-0002).
+ *
+ * @param type - The line kind.
+ * @returns The badge label, or `undefined` for kinds shown without a badge.
+ */
+export function commandBadge(type: CommandType): string | undefined {
+  switch (type) {
+    case CommandType.title:
+      return "TITLE";
+    case CommandType.error:
+      return "ERR";
+    case CommandType.status:
+      return "OK";
+    default:
+      return undefined;
+  }
+}
+
 type TerminalCoreOptions = {
   /** Command registry; consumers register their own command sets. */
   commands: Record<string, CommandHandler>;
@@ -112,9 +132,12 @@ export class TerminalCore {
 
     const lines = String(text).replace(/\r\n/g, "\n").split("\n");
 
+    const badge = commandBadge(kind);
+
     for (const line of lines) {
       const p = document.createElement("p");
       p.className = `terminal-msg ${CommandType[kind]}`;
+      if (badge) p.dataset.badge = badge;
       p.textContent = "";
       log.appendChild(p);
 

--- a/v2-blog/src/_includes/css/terminal.css
+++ b/v2-blog/src/_includes/css/terminal.css
@@ -39,9 +39,9 @@ html {
 
   --font-mono: 'IBM Plex Mono', ui-monospace, 'Cascadia Code', 'Source Code Pro', 'Menlo', 'Monaco', 'Consolas', 'Roboto Mono', 'Courier New', monospace;
 
-  /* Terminal palette — derived from the theme's pink accent (hue) mixed toward
-     white per theme brightness (ADR-0002). Keep in sync with global.css. */
-  --term-bg: color-mix(in oklab, var(--color-accent-primary) 6%, white);
+  /* Terminal palette (ADR-0002). Background uses the theme default; surface,
+     border and text share the pink accent hue. Keep in sync with global.css. */
+  --term-bg: var(--color-bg-default);
   --term-surface: color-mix(in oklab, var(--color-accent-primary) 12%, white);
   --term-border: color-mix(in oklab, var(--color-accent-primary) 28%, white);
   --term-text: color-mix(in oklab, var(--color-accent-primary) 78%, black);
@@ -68,7 +68,7 @@ html.dark {
   --color-text: var(--color-text-primary);
 
   /* Dark theme: same pink hue, mixed toward black (ADR-0002). */
-  --term-bg: color-mix(in oklab, var(--color-accent-primary) 8%, #0c0a14);
+  --term-bg: var(--color-bg-default);
   --term-surface: color-mix(in oklab, var(--color-accent-primary) 14%, #0c0a14);
   --term-border: color-mix(in oklab, var(--color-accent-primary) 22%, var(--color-gray-800));
   --term-text: color-mix(in oklab, var(--color-accent-primary) 32%, white);

--- a/v2-blog/src/_includes/css/terminal.css
+++ b/v2-blog/src/_includes/css/terminal.css
@@ -38,6 +38,20 @@ html {
   --color-text: var(--color-text-primary);
 
   --font-mono: 'IBM Plex Mono', ui-monospace, 'Cascadia Code', 'Source Code Pro', 'Menlo', 'Monaco', 'Consolas', 'Roboto Mono', 'Courier New', monospace;
+
+  /* Terminal palette — derived from the theme's pink accent (hue) mixed toward
+     white per theme brightness (ADR-0002). Keep in sync with global.css. */
+  --term-bg: color-mix(in oklab, var(--color-accent-primary) 6%, white);
+  --term-surface: color-mix(in oklab, var(--color-accent-primary) 12%, white);
+  --term-border: color-mix(in oklab, var(--color-accent-primary) 28%, white);
+  --term-text: color-mix(in oklab, var(--color-accent-primary) 78%, black);
+  --term-muted: color-mix(in oklab, var(--color-accent-primary) 45%, var(--color-gray-500));
+  --term-accent: var(--color-accent-primary);
+  --term-on-accent: var(--color-pink-50);
+  --term-prompt: var(--color-accent-primary);
+  --term-ok-bg: #2fa46a;
+  --term-err-bg: #e5484d;
+  --term-badge-text: #fff;
 }
 
 html.dark {
@@ -52,6 +66,17 @@ html.dark {
   --color-code-bg: var(--color-gray-900);
   --color-code-border: var(--color-gray-800);
   --color-text: var(--color-text-primary);
+
+  /* Dark theme: same pink hue, mixed toward black (ADR-0002). */
+  --term-bg: color-mix(in oklab, var(--color-accent-primary) 8%, #0c0a14);
+  --term-surface: color-mix(in oklab, var(--color-accent-primary) 14%, #0c0a14);
+  --term-border: color-mix(in oklab, var(--color-accent-primary) 22%, var(--color-gray-800));
+  --term-text: color-mix(in oklab, var(--color-accent-primary) 32%, white);
+  --term-muted: color-mix(in oklab, var(--color-accent-primary) 45%, var(--color-gray-500));
+  --term-on-accent: var(--color-gray-900);
+  --term-ok-bg: #46d18a;
+  --term-err-bg: #ff6b6b;
+  --term-badge-text: #15131f;
 }
 
 @keyframes blink {
@@ -136,10 +161,11 @@ terminal-shell {
   width: 100%;
   height: 100%;
   padding: 1rem;
-  color: var(--color-text);
+  background-color: var(--term-bg);
+  color: var(--term-text);
   font-family: var(--font-mono);
   text-transform: lowercase;
-  border: 1px solid var(--color-code-border);
+  border: 1px solid var(--term-border);
 }
 
 

--- a/v2-blog/src/assets/styles/books-terminal-deferred.css
+++ b/v2-blog/src/assets/styles/books-terminal-deferred.css
@@ -90,34 +90,55 @@ html.dark {
 
 #boot-log {
   p {
-    max-width: 600px;
+    max-width: 640px;
     padding-block: 2px;
   }
 
-  .title {
-    position: relative;
+  /* Linear-stream lines: command echoes get a prompt glyph; title/error/status
+     get an uppercase badge pill from the core's data-badge attribute. */
+  .terminal-msg {
     display: flex;
-    justify-content: center;
-    padding-block: 1rem;
-    color: var(--color-accent-primary);
-    overflow: hidden;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0 0.6ch;
   }
 
-  .title::before {
+  .terminal-msg[data-badge]::before {
+    content: attr(data-badge);
+    flex: none;
+    align-self: flex-start;
+    padding: 0 0.6ch;
+    font-weight: 600;
+    font-size: 0.82em;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    background: var(--term-accent);
+    color: var(--term-on-accent);
+  }
+
+  .error[data-badge]::before {
+    background: var(--term-err-bg);
+    color: var(--term-badge-text);
+  }
+
+  .status[data-badge]::before {
+    background: var(--term-ok-bg);
+    color: var(--term-badge-text);
+  }
+
+  .command {
+    position: sticky;
     top: 0;
-  }
-
-  .title::after {
-    bottom: 0;
-  }
-
-  .title::before,
-  .title::after {
-    position: absolute;
-    content: "=====================================================================================================================================================================================================================================================================================";
-    width: 100%;
     left: 0;
-    white-space: nowrap;
+    color: var(--term-prompt);
+    background-color: var(--term-bg);
+    z-index: 5;
+  }
+
+  .command::before {
+    content: "$";
+    flex: none;
+    font-weight: 600;
   }
 
   .logdata {
@@ -126,32 +147,38 @@ html.dark {
       text-indent: 3rem;
     }
   }
+}
 
-  .error {
-    color: var(--color-pink-700);
-  }
+/* Segmented vim-style status bar at the foot of the books terminal. */
+#terminal-status {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  margin-block-start: 0.75rem;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
 
-  .command {
-    position: sticky;
-    top: 0;
-    left: 0;
+  & > span {
     display: flex;
-    justify-content: space-between;
-    color: var(--color-accent-primary);
-    background-color: var(--color-bg-default);
-    z-index: 5;
+    align-items: center;
+    padding: 0.2rem 0.8rem;
   }
 
-  .command::before {
-    content: "[";
-    display: inline-block;
-    margin-inline-end: 5px;
+  .status-mode {
+    background: var(--term-accent);
+    color: var(--term-on-accent);
+    text-transform: uppercase;
   }
 
-  .command::after {
-    content: "]";
-    display: inline-block;
-    margin-inline-start: auto;
+  .status-path {
+    flex: 1;
+    color: var(--term-muted);
+  }
+
+  .status-id {
+    background: var(--term-surface);
+    color: var(--term-muted);
   }
 }
 

--- a/v2-blog/src/assets/styles/global.css
+++ b/v2-blog/src/assets/styles/global.css
@@ -100,9 +100,9 @@
     --color-h3: color-mix(in oklab, var(--color-pink-950) 90%, white 10%);
     --color-h4: color-mix(in oklab, var(--color-pink-950) 95%, white 5%);
 
-    /* Terminal palette — pink-accent hue, light brightness (ADR-0002).
-       Keep in sync with src/_includes/css/terminal.css. */
-    --term-bg: color-mix(in oklab, var(--color-accent-primary) 6%, white);
+    /* Terminal palette (ADR-0002). Background uses the theme default; surface,
+       border and text share the pink accent hue. Keep in sync with terminal.css. */
+    --term-bg: var(--color-bg-default);
     --term-surface: color-mix(in oklab, var(--color-accent-primary) 12%, white);
     --term-border: color-mix(in oklab, var(--color-accent-primary) 28%, white);
     --term-text: color-mix(in oklab, var(--color-accent-primary) 78%, black);
@@ -140,7 +140,7 @@
     --color-sidebar: var(--color-gray-800);
 
     /* Dark theme: same pink hue, mixed toward black (ADR-0002). */
-    --term-bg: color-mix(in oklab, var(--color-accent-primary) 8%, #0c0a14);
+    --term-bg: var(--color-bg-default);
     --term-surface: color-mix(in oklab, var(--color-accent-primary) 14%, #0c0a14);
     --term-border: color-mix(in oklab, var(--color-accent-primary) 22%, var(--color-gray-800));
     --term-text: color-mix(in oklab, var(--color-accent-primary) 32%, white);

--- a/v2-blog/src/assets/styles/global.css
+++ b/v2-blog/src/assets/styles/global.css
@@ -99,6 +99,20 @@
     --color-h2: color-mix(in oklab, var(--color-pink-900) 90%, white 10%);
     --color-h3: color-mix(in oklab, var(--color-pink-950) 90%, white 10%);
     --color-h4: color-mix(in oklab, var(--color-pink-950) 95%, white 5%);
+
+    /* Terminal palette — pink-accent hue, light brightness (ADR-0002).
+       Keep in sync with src/_includes/css/terminal.css. */
+    --term-bg: color-mix(in oklab, var(--color-accent-primary) 6%, white);
+    --term-surface: color-mix(in oklab, var(--color-accent-primary) 12%, white);
+    --term-border: color-mix(in oklab, var(--color-accent-primary) 28%, white);
+    --term-text: color-mix(in oklab, var(--color-accent-primary) 78%, black);
+    --term-muted: color-mix(in oklab, var(--color-accent-primary) 45%, var(--color-gray-500));
+    --term-accent: var(--color-accent-primary);
+    --term-on-accent: var(--color-pink-50);
+    --term-prompt: var(--color-accent-primary);
+    --term-ok-bg: #2fa46a;
+    --term-err-bg: #e5484d;
+    --term-badge-text: #fff;
   }
 
   html.dark {
@@ -124,6 +138,17 @@
     --color-scroll-track: var(--color-gray-800);
     --color-scroll-thumb: var(--color-gray-700);
     --color-sidebar: var(--color-gray-800);
+
+    /* Dark theme: same pink hue, mixed toward black (ADR-0002). */
+    --term-bg: color-mix(in oklab, var(--color-accent-primary) 8%, #0c0a14);
+    --term-surface: color-mix(in oklab, var(--color-accent-primary) 14%, #0c0a14);
+    --term-border: color-mix(in oklab, var(--color-accent-primary) 22%, var(--color-gray-800));
+    --term-text: color-mix(in oklab, var(--color-accent-primary) 32%, white);
+    --term-muted: color-mix(in oklab, var(--color-accent-primary) 45%, var(--color-gray-500));
+    --term-on-accent: var(--color-gray-900);
+    --term-ok-bg: #46d18a;
+    --term-err-bg: #ff6b6b;
+    --term-badge-text: #15131f;
 
     --color-h1: var(--color-accent-primary);
     --color-h2: var(--color-pink-400);

--- a/v2-blog/src/components/terminal-overlay.ts
+++ b/v2-blog/src/components/terminal-overlay.ts
@@ -33,12 +33,12 @@ export class TerminalOverlay extends LitElement {
       max-height: 45vh;
       padding: 0;
       border: 0;
-      border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+      border-bottom: 1px solid var(--term-border);
       display: block;
       transform: translateY(-100%);
-      color: #e8e6e3;
+      color: var(--term-text);
       box-shadow: 0 12px 40px rgba(0, 0, 0, 0.45);
-      font-family: ui-monospace, "IBM Plex Mono", monospace;
+      font-family: var(--font-mono, ui-monospace, "IBM Plex Mono", monospace);
     }
 
     /* A real painted fill rather than a CSS background on the popover element:
@@ -48,7 +48,7 @@ export class TerminalOverlay extends LitElement {
       position: absolute;
       inset: 0;
       z-index: 0;
-      background: rgba(20, 18, 24, 0.96);
+      background: var(--term-bg);
     }
 
     #overlay-inner {
@@ -73,17 +73,87 @@ export class TerminalOverlay extends LitElement {
       line-height: 1.5;
     }
 
+    /* Linear-stream lines: badge pills from the core's data-badge attribute. */
+    .terminal-msg {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: baseline;
+      gap: 0 0.6ch;
+    }
+
+    .terminal-msg[data-badge]::before {
+      content: attr(data-badge);
+      flex: none;
+      align-self: flex-start;
+      padding: 0 0.6ch;
+      font-weight: 600;
+      font-size: 0.82em;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      background: var(--term-accent);
+      color: var(--term-on-accent);
+    }
+
+    .terminal-msg.error[data-badge]::before {
+      background: var(--term-err-bg);
+      color: var(--term-badge-text);
+    }
+
+    .terminal-msg.status[data-badge]::before {
+      background: var(--term-ok-bg);
+      color: var(--term-badge-text);
+    }
+
+    .terminal-msg.command::before {
+      content: "$";
+      flex: none;
+      color: var(--term-prompt);
+      font-weight: 600;
+    }
+
     #overlay-form {
       display: flex;
       align-items: center;
       gap: 0.5rem;
-      border-top: 1px solid rgba(255, 255, 255, 0.12);
+      border-top: 1px solid var(--term-border);
       padding: 0.6rem 1.25rem;
     }
 
     #overlay-form::before {
       content: "$";
-      opacity: 0.6;
+      color: var(--term-prompt);
+      font-weight: 600;
+    }
+
+    /* Segmented vim-style status bar. */
+    #overlay-status {
+      display: flex;
+      align-items: stretch;
+      font-size: 0.72rem;
+      font-weight: 600;
+      letter-spacing: 0.04em;
+    }
+
+    #overlay-status > span {
+      padding: 0.2rem 0.8rem;
+      display: flex;
+      align-items: center;
+    }
+
+    .status-mode {
+      background: var(--term-accent);
+      color: var(--term-on-accent);
+      text-transform: uppercase;
+    }
+
+    .status-path {
+      flex: 1;
+      color: var(--term-muted);
+    }
+
+    .status-id {
+      background: var(--term-surface);
+      color: var(--term-muted);
     }
 
     #overlay-input {
@@ -280,6 +350,11 @@ export class TerminalOverlay extends LitElement {
               autocomplete="off"
             ></textarea>
           </form>
+          <div id="overlay-status" aria-hidden="true">
+            <span class="status-mode">cheat</span>
+            <span class="status-path">~/book_os</span>
+            <span class="status-id">◍ reader</span>
+          </div>
         </div>
       </section>
     `;

--- a/v2-blog/src/components/terminal-shell.ts
+++ b/v2-blog/src/components/terminal-shell.ts
@@ -916,6 +916,11 @@ export class TerminalShell extends LitElement {
               id="terminal-text"><span id="terminal-mirror">${this.shell.command}</span><span id="caret-anchor">&#8203;</span><span id="fake-caret" aria-hidden="true"></span></div>
           </div>
         </form>
+        <footer id="terminal-status" aria-hidden="true">
+          <span class="status-mode">${this.shell.routeMode === "detail" ? "read" : "browse"}</span>
+          <span class="status-path">~/book_os</span>
+          <span class="status-id">◍ ${this.userID || "reader"}</span>
+        </footer>
       </div>
     `;
   }

--- a/v2-blog/tests/unit/helpers/terminal/command-badge.test.ts
+++ b/v2-blog/tests/unit/helpers/terminal/command-badge.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { CommandType, commandBadge } from "../../../../src/_helpers/terminal/core.ts";
+
+describe("commandBadge", () => {
+  it("labels title, error, and status lines", () => {
+    expect(commandBadge(CommandType.title)).toBe("TITLE");
+    expect(commandBadge(CommandType.error)).toBe("ERR");
+    expect(commandBadge(CommandType.status)).toBe("OK");
+  });
+
+  it("gives no badge to command, log, and logdata lines", () => {
+    expect(commandBadge(CommandType.command)).toBeUndefined();
+    expect(commandBadge(CommandType.log)).toBeUndefined();
+    expect(commandBadge(CommandType.logdata)).toBeUndefined();
+  });
+});

--- a/v2-blog/tests/unit/helpers/terminal/core.test.ts
+++ b/v2-blog/tests/unit/helpers/terminal/core.test.ts
@@ -58,6 +58,16 @@ describe("TerminalCore", () => {
     expect(logEl.querySelectorAll("p.terminal-msg.log")[1].textContent).toBe("second");
   });
 
+  it("stamps a data-badge on badged kinds and omits it on plain kinds", async () => {
+    const { core, logEl } = createCore();
+
+    await core.append("uh oh", 0, CommandType.error);
+    await core.append("just info", 0, CommandType.log);
+
+    expect(logEl.querySelector("p.error")?.getAttribute("data-badge")).toBe("ERR");
+    expect(logEl.querySelector("p.log")?.hasAttribute("data-badge")).toBe(false);
+  });
+
   it("notifies onLineWritten after each appended line", async () => {
     const onLineWritten = vi.fn();
     const { core, logEl } = createCore({ onLineWritten });


### PR DESCRIPTION
Closes #86. Implements the linear-stream look chosen via /prototype-terminal (variant B) and the palette decision in ADR-0002.

## What changed

Both terminal surfaces — the books page and the summon overlay — now share one linear-stream aesthetic:
- A `$` prompt glyph on command echoes.
- Uppercase **badge pills** on title/error/status lines (`TITLE` pink, `ERR` red, `OK` green).
- A segmented vim-style **status bar** (mode · path · identity).
- Square corners.

### Badges are consistent by construction
A pure `commandBadge(type)` (in the shared core) maps `CommandType → label`, and `core.append()` stamps `data-badge`; CSS renders it with `content: attr(data-badge)`. Both surfaces use the same core, so badges can't drift between them — that satisfies the "consistent across surfaces" criterion at the source rather than via duplicated CSS.

### Theme-derived palette (ADR-0002)
`--term-*` tokens are derived from the primary-pink accent **hue**, mixed toward white/black per theme **brightness** with `color-mix(in oklab, …)` (the existing codebase idiom). Defined on `:root`/`html.dark` in **both** `terminal.css` (books, inlined) and `global.css` (overlay — inherited into the shadow DOM, since the overlay can't select `html.dark` from inside its shadow). The terminal flips with the theme toggle; no recolor flash (tokens are pre-paint).

This replaced the books terminal's old `===` title separators / `[ ]` command brackets in `books-terminal-deferred.css`.

## Tests & verification
- TDD: `commandBadge` mapping + `append` data-badge stamping. **91 unit tests** green, typecheck clean, **stylelint + ESLint** clean, build green, Playwright e2e green.
- Visual verification via the **chrome-devtools MCP**: books page and overlay, in **both pinky and dark themes**, at desktop and mobile (390px) widths — badges, prompt, status bar, and palette all confirmed.

## Cleanup
The throwaway `/prototype-terminal/` page is deleted now that the look is folded in.

Independent of #85 (state reducer); both are now landed/queued.