### PR TITLE
feat(terminal): site navigation (ls/list + open)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -19,3 +19,7 @@ _Avoid_: open, launch, invoke
 **Terminal palette**:
 The Terminal's own colour token set, derived from the active site theme's primary-pink **hue** and **brightness** rather than copied from the site's base tokens or fixed dark. It flips with the theme toggle while keeping its own contrast/accent structure. See [ADR-0002](docs/adr/0002-terminal-palette-derived-from-theme.md).
 _Avoid_: terminal colors, terminal theme
+
+**Site index**:
+The build-time manifest of navigable pages — blog posts, books, and top-level pages — that the Terminal lists with `ls` and navigates with `open`. The Terminal models it as a **tree** keyed on each page's real URL: containers (`blog/`, `books/`, year levels) are **folders** that carry a descendant count; individual pages are **leaves**. Page URLs always come from real Eleventy permalinks, never hardcoded.
+_Avoid_: sitemap, manifest, catalog

--- a/v2-blog/eleventy.config.ts
+++ b/v2-blog/eleventy.config.ts
@@ -144,6 +144,7 @@ export default function (eleventyConfig: any) {
 
 
   eleventyConfig.addCollection("projects", collections.projects);
+  eleventyConfig.addCollection("pages", collections.pages);
   eleventyConfig.addCollection("published", collections.published);
   eleventyConfig.addCollection("notesPublished", collections.notesPublished);
 

--- a/v2-blog/src/_config/collections.js
+++ b/v2-blog/src/_config/collections.js
@@ -5,6 +5,10 @@ export default {
   games: function (collectionApi) {
     return collectionApi.getFilteredByGlob('src/games/**/*.md');
   },
+  pages: function (collectionApi) {
+    // Top-level pages (home, blog, notes, books, about, games, copyright).
+    return collectionApi.getFilteredByGlob('src/pages/**/*.{njk,md}');
+  },
   published: function (collectionApi) {
     const now = new Date();
 

--- a/v2-blog/src/_helpers/terminal/site-index.ts
+++ b/v2-blog/src/_helpers/terminal/site-index.ts
@@ -136,17 +136,34 @@ export function renderSubtree(node: TreeNode): string[] {
 }
 
 /**
- * Finds a tree node by name (case-insensitive), searching depth-first.
+ * Resolves a query to a tree node. A bare name is searched depth-first
+ * (so `ring` finds a nested book); a slash path (`blog/2025`) is walked
+ * segment by segment from `node`.
  *
  * @param node - The node to search from (typically the root).
- * @param name - The folder/leaf name to find.
- * @returns The first matching node, or `undefined`.
+ * @param query - A name or a slash-separated path.
+ * @returns The matching node, or `undefined`.
  */
-export function findNode(node: TreeNode, name: string): TreeNode | undefined {
-  const n = name.trim().toLowerCase();
+export function findNode(node: TreeNode, query: string): TreeNode | undefined {
+  const segments = query.trim().split("/").filter(Boolean);
+  if (segments.length === 0) return undefined;
+
+  if (segments.length > 1) {
+    let current: TreeNode | undefined = node;
+    for (const segment of segments) {
+      current = current?.children.find((c) => c.name.toLowerCase() === segment.toLowerCase());
+    }
+    return current;
+  }
+
+  return dfsByName(node, segments[0].toLowerCase());
+}
+
+/** Depth-first search for the first node whose name matches (lowercased). */
+function dfsByName(node: TreeNode, name: string): TreeNode | undefined {
   for (const child of node.children) {
-    if (child.name.toLowerCase() === n) return child;
-    const deeper = findNode(child, name);
+    if (child.name.toLowerCase() === name) return child;
+    const deeper = dfsByName(child, name);
     if (deeper) return deeper;
   }
   return undefined;

--- a/v2-blog/src/_helpers/terminal/site-index.ts
+++ b/v2-blog/src/_helpers/terminal/site-index.ts
@@ -1,0 +1,101 @@
+/** Built URL of the site index manifest. */
+const SITE_INDEX_URL = "/assets/site-index.json";
+
+/** Per-page-load cache of the fetched, parsed index. */
+let cachedIndex: Promise<SiteIndexEntry[]> | undefined;
+
+/** A navigable entry in the site index (one page of content). */
+export interface SiteIndexEntry {
+  section: "posts" | "books" | "pages";
+  title: string;
+  url: string;
+  date?: string;
+}
+
+/** The outcome of resolving an `open <query>` against the index. */
+export type MatchResult =
+  | { kind: "match"; entry: SiteIndexEntry }
+  | { kind: "ambiguous"; entries: SiteIndexEntry[] }
+  | { kind: "none" };
+
+/** Extracts the slug (last non-empty path segment) from a URL. */
+function slugOf(url: string): string {
+  return url.split("/").filter(Boolean).pop() ?? "";
+}
+
+/**
+ * Resolves an `open` query against the index: an exact slug wins; otherwise a
+ * single partial (slug or title) match wins; multiple are ambiguous.
+ *
+ * @param entries - The site index.
+ * @param query - The user's `open` argument.
+ * @returns A match, an ambiguous set, or none.
+ */
+export function matchEntry(entries: SiteIndexEntry[], query: string): MatchResult {
+  const q = query.trim().toLowerCase();
+  if (!q) return { kind: "none" };
+
+  const exact = entries.find((e) => slugOf(e.url).toLowerCase() === q);
+  if (exact) return { kind: "match", entry: exact };
+
+  const partial = entries.filter(
+    (e) => slugOf(e.url).toLowerCase().includes(q) || e.title.toLowerCase().includes(q)
+  );
+
+  if (partial.length === 1) return { kind: "match", entry: partial[0] };
+  if (partial.length > 1) return { kind: "ambiguous", entries: partial };
+  return { kind: "none" };
+}
+
+/**
+ * Lazily fetches and parses the site index, caching it for the page load.
+ * Coalesces concurrent calls; a failed fetch resolves to `[]` and is retryable.
+ *
+ * @returns A promise of the parsed site index entries.
+ */
+export function fetchSiteIndex(): Promise<SiteIndexEntry[]> {
+  if (!cachedIndex) {
+    cachedIndex = fetch(SITE_INDEX_URL, { cache: "force-cache" })
+      .then((res) => (res.ok ? res.json() : []))
+      .then(parseSiteIndex)
+      .catch(() => {
+        cachedIndex = undefined;
+        return [];
+      });
+  }
+  return cachedIndex;
+}
+
+/**
+ * Filters the index by section for the `ls` / `list <section>` command.
+ *
+ * @param entries - The site index.
+ * @param section - Optional section name (case-insensitive); omitted returns all.
+ * @returns The matching entries (empty for an unknown section).
+ */
+export function filterSection(entries: SiteIndexEntry[], section?: string): SiteIndexEntry[] {
+  if (!section) return entries;
+  const s = section.trim().toLowerCase();
+  return entries.filter((e) => e.section === s);
+}
+
+/**
+ * Normalizes the fetched site-index payload into well-formed entries.
+ * Tolerates extra fields (forward-compatible with future search metadata).
+ *
+ * @param raw - The parsed JSON payload.
+ * @returns The valid entries; malformed input yields an empty array.
+ */
+export function parseSiteIndex(raw: unknown): SiteIndexEntry[] {
+  if (!Array.isArray(raw)) return [];
+
+  return raw
+    .filter((item): item is Record<string, unknown> =>
+      !!item && typeof item.title === "string" && typeof item.url === "string")
+    .map((item) => ({
+      section: item.section as SiteIndexEntry["section"],
+      title: item.title as string,
+      url: item.url as string,
+      date: typeof item.date === "string" ? item.date : undefined,
+    }));
+}

--- a/v2-blog/src/_helpers/terminal/site-index.ts
+++ b/v2-blog/src/_helpers/terminal/site-index.ts
@@ -169,11 +169,64 @@ function dfsByName(node: TreeNode, name: string): TreeNode | undefined {
   return undefined;
 }
 
+/**
+ * Sanitizes a user-typed navigation argument: lowercases, keeps only
+ * slug/path characters (letters, digits, `/`, `-`, `_`, space), collapses
+ * repeated separators, strips edge slashes (no path traversal), and caps length.
+ *
+ * @param input - The raw user argument.
+ * @returns The cleaned query, safe to match against the index.
+ */
+export function sanitizeNavQuery(input: string): string {
+  return input
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9/_ -]/g, "")
+    .replace(/\/+/g, "/")
+    .replace(/ +/g, " ")
+    .replace(/^\/+|\/+$/g, "")
+    .slice(0, 120);
+}
+
 /** The outcome of resolving an `open <query>` against the index. */
 export type MatchResult =
   | { kind: "match"; entry: SiteIndexEntry }
   | { kind: "ambiguous"; entries: SiteIndexEntry[] }
   | { kind: "none" };
+
+/** The outcome of resolving an `open <query>`. */
+export type OpenResult =
+  | { kind: "navigate"; url: string; title: string }
+  | { kind: "ambiguous"; entries: SiteIndexEntry[] }
+  | { kind: "not-a-page" }
+  | { kind: "none" };
+
+/**
+ * Resolves an `open` query to a navigation target. A slash path is walked
+ * through the tree (a page-less folder like a year yields `not-a-page`); a
+ * bare query falls back to slug/title matching. Navigation always targets a
+ * URL from the index, never the raw user input.
+ *
+ * @param root - The site tree.
+ * @param entries - The flat index (for bare slug/title matching).
+ * @param query - The sanitized user argument.
+ * @returns What `open` should do.
+ */
+export function resolveOpen(root: TreeNode, entries: SiteIndexEntry[], query: string): OpenResult {
+  if (!query) return { kind: "none" };
+
+  if (query.includes("/")) {
+    const node = findNode(root, query);
+    if (!node) return { kind: "none" };
+    if (!node.url) return { kind: "not-a-page" };
+    return { kind: "navigate", url: node.url, title: node.title ?? node.name };
+  }
+
+  const match = matchEntry(entries, query);
+  if (match.kind === "match") return { kind: "navigate", url: match.entry.url, title: match.entry.title };
+  if (match.kind === "ambiguous") return { kind: "ambiguous", entries: match.entries };
+  return { kind: "none" };
+}
 
 /** Extracts the slug (last non-empty path segment) from a URL. */
 function slugOf(url: string): string {

--- a/v2-blog/src/_helpers/terminal/site-index.ts
+++ b/v2-blog/src/_helpers/terminal/site-index.ts
@@ -6,10 +6,150 @@ let cachedIndex: Promise<SiteIndexEntry[]> | undefined;
 
 /** A navigable entry in the site index (one page of content). */
 export interface SiteIndexEntry {
-  section: "posts" | "books" | "pages";
+  section: "blog" | "books" | "pages";
   title: string;
   url: string;
   date?: string;
+  description?: string;
+}
+
+/**
+ * A node in the URL-derived site tree. Folders have children; leaves don't.
+ * `url`/`title`/`description` are present when a page exists at this exact path
+ * (intermediate path segments like a year folder have children but no page).
+ */
+export interface TreeNode {
+  name: string;
+  children: TreeNode[];
+  count: number;
+  url?: string;
+  title?: string;
+  description?: string;
+}
+
+/**
+ * Builds a tree from index entries, keyed on URL path segments. Each entry's
+ * path becomes a chain of folder nodes ending in a node carrying its page data.
+ *
+ * @param entries - The site index.
+ * @returns The synthetic root node whose children are the top level.
+ */
+export function buildTree(entries: SiteIndexEntry[]): TreeNode {
+  const root: TreeNode = { name: ".", children: [], count: 0 };
+
+  for (const entry of entries) {
+    const segments = entry.url.split("/").filter(Boolean);
+    const path = segments.length ? segments : ["home"];
+
+    let node = root;
+    for (const segment of path) {
+      let child = node.children.find((c) => c.name === segment);
+      if (!child) {
+        child = { name: segment, children: [], count: 0 };
+        node.children.push(child);
+      }
+      node = child;
+    }
+
+    node.url = entry.url;
+    node.title = entry.title;
+    node.description = entry.description;
+  }
+
+  assignCounts(root);
+  return root;
+}
+
+/**
+ * Assigns each folder node its count of descendant leaf pages (recursive).
+ * Leaves get a count of 0.
+ *
+ * @param node - The node to count from.
+ * @returns The number of leaf descendants contributed by `node`.
+ */
+function assignCounts(node: TreeNode): number {
+  if (node.children.length === 0) {
+    node.count = 0;
+    return 1;
+  }
+  let sum = 0;
+  for (const child of node.children) sum += assignCounts(child);
+  node.count = sum;
+  return sum;
+}
+
+/** Whether a node is a folder (has children). */
+function isFolder(node: TreeNode): boolean {
+  return node.children.length > 0;
+}
+
+/**
+ * Renders the top level of the tree for a bare `ls`: folders first
+ * (`name/   count`), then leaf pages (plain name).
+ *
+ * @param root - The tree root.
+ * @returns The lines to print.
+ */
+export function renderRootListing(root: TreeNode): string[] {
+  const folders = root.children.filter(isFolder);
+  const leaves = root.children.filter((n) => !isFolder(n));
+
+  return [
+    ...folders.map((f) => `${f.name}/   ${f.count}`),
+    ...leaves.map((l) => l.name),
+  ];
+}
+
+/** Renders a folder/leaf label: folders show `name/   count`, leaves `name`. */
+function nodeLabel(node: TreeNode): string {
+  return isFolder(node) ? `${node.name}/   ${node.count}` : node.name;
+}
+
+/**
+ * Renders a node's descendants as an ASCII tree with box-drawing connectors.
+ *
+ * @param node - The folder whose children to render.
+ * @param prefix - The accumulated indentation prefix.
+ * @returns The tree lines.
+ */
+function renderChildren(node: TreeNode, prefix: string): string[] {
+  const lines: string[] = [];
+  node.children.forEach((child, i) => {
+    const last = i === node.children.length - 1;
+    lines.push(prefix + (last ? "└── " : "├── ") + nodeLabel(child));
+    if (isFolder(child)) {
+      lines.push(...renderChildren(child, prefix + (last ? "    " : "│   ")));
+    }
+  });
+  return lines;
+}
+
+/**
+ * Renders a folder node as a full `tree`-style listing (`ls <folder>`),
+ * with the folder name as the header and its subtree beneath.
+ *
+ * @param node - The folder to render.
+ * @returns The lines to print.
+ */
+export function renderSubtree(node: TreeNode): string[] {
+  return [isFolder(node) ? `${node.name}/` : node.name, ...renderChildren(node, "")];
+}
+
+/**
+ * Finds a tree node by name (case-insensitive), searching depth-first.
+ *
+ * @param node - The node to search from (typically the root).
+ * @param name - The folder/leaf name to find.
+ * @returns The first matching node, or `undefined`.
+ */
+export function findNode(node: TreeNode, name: string): TreeNode | undefined {
+  const n = name.trim().toLowerCase();
+  for (const child of node.children) {
+    if (child.name.toLowerCase() === n) return child;
+    const deeper = findNode(child, name);
+    if (deeper) return deeper;
+  }
+  return undefined;
 }
 
 /** The outcome of resolving an `open <query>` against the index. */
@@ -55,7 +195,9 @@ export function matchEntry(entries: SiteIndexEntry[], query: string): MatchResul
  */
 export function fetchSiteIndex(): Promise<SiteIndexEntry[]> {
   if (!cachedIndex) {
-    cachedIndex = fetch(SITE_INDEX_URL, { cache: "force-cache" })
+    // no-cache (revalidate), not force-cache: the manifest changes whenever
+    // content is added/deployed, so a stale cached copy must not be served.
+    cachedIndex = fetch(SITE_INDEX_URL, { cache: "no-cache" })
       .then((res) => (res.ok ? res.json() : []))
       .then(parseSiteIndex)
       .catch(() => {
@@ -64,19 +206,6 @@ export function fetchSiteIndex(): Promise<SiteIndexEntry[]> {
       });
   }
   return cachedIndex;
-}
-
-/**
- * Filters the index by section for the `ls` / `list <section>` command.
- *
- * @param entries - The site index.
- * @param section - Optional section name (case-insensitive); omitted returns all.
- * @returns The matching entries (empty for an unknown section).
- */
-export function filterSection(entries: SiteIndexEntry[], section?: string): SiteIndexEntry[] {
-  if (!section) return entries;
-  const s = section.trim().toLowerCase();
-  return entries.filter((e) => e.section === s);
 }
 
 /**
@@ -97,5 +226,6 @@ export function parseSiteIndex(raw: unknown): SiteIndexEntry[] {
       title: item.title as string,
       url: item.url as string,
       date: typeof item.date === "string" ? item.date : undefined,
+      description: typeof item.description === "string" ? item.description : undefined,
     }));
 }

--- a/v2-blog/src/components/terminal-overlay.ts
+++ b/v2-blog/src/components/terminal-overlay.ts
@@ -4,7 +4,14 @@ import { adoptTailwind } from "../_helpers/styleLoader.ts";
 import { animator } from "../_helpers/animationManager.ts";
 import { CommandType, TerminalCore } from "../_helpers/terminal/core.ts";
 import type { ParsedCommand } from "../_helpers/terminal/parser.ts";
-import { fetchSiteIndex, filterSection, matchEntry } from "../_helpers/terminal/site-index.ts";
+import {
+  buildTree,
+  fetchSiteIndex,
+  findNode,
+  matchEntry,
+  renderRootListing,
+  renderSubtree,
+} from "../_helpers/terminal/site-index.ts";
 
 /**
  * Site-wide summonable terminal overlay (the "cheat console").
@@ -194,7 +201,7 @@ export class TerminalOverlay extends LitElement {
       help: async (ctx: ParsedCommand) => {
         await this._core.append(ctx.raw, 0.2, CommandType.command);
         await this._core.append(
-          "help - list commands\nls [section] - list site content (posts, books, pages)\nopen <slug> - go to a page",
+          "help - list commands\nls [folder] - browse the site tree (blog, books, …)\nopen <slug> - go to a page",
           0.3,
           CommandType.logdata
         );
@@ -235,26 +242,43 @@ export class TerminalOverlay extends LitElement {
   });
 
   /**
-   * Lists site content for `ls` / `list [section]`, optionally filtered.
+   * Handles `ls [target]` against the site tree:
+   * - no arg → the top level (folders with counts, then leaf pages);
+   * - a folder → its `tree`-style subtree;
+   * - a leaf → its title and description.
    *
-   * @param ctx - The parsed command (first positional is an optional section).
-   * @returns A promise that settles once the listing is written.
+   * @param ctx - The parsed command (first positional is an optional target).
+   * @returns A promise that settles once the output is written.
    */
   private async _listContent(ctx: ParsedCommand): Promise<void> {
     await this._core.append(ctx.raw, 0.2, CommandType.command);
 
-    const section = ctx.positionals[0];
-    const entries = filterSection(await fetchSiteIndex(), section);
+    const root = buildTree(await fetchSiteIndex());
+    const target = ctx.positionals[0];
 
-    if (entries.length === 0) {
-      await this._core.append(section ? `nothing in "${section}"` : "nothing to list", 0.2, CommandType.error);
+    if (!target) {
+      for (const line of renderRootListing(root)) {
+        await this._core.append(line, 0.02, CommandType.log);
+      }
       return;
     }
 
-    await this._core.append(section ? section : "all content", 0.2, CommandType.title);
-    for (const entry of entries) {
-      await this._core.append(`  ${entry.title}`, 0.05, CommandType.logdata);
+    const node = findNode(root, target);
+    if (!node) {
+      await this._core.append(`ls: ${target}: no such page`, 0.2, CommandType.error);
+      return;
     }
+
+    if (node.children.length > 0) {
+      for (const line of renderSubtree(node)) {
+        await this._core.append(line, 0.02, CommandType.log);
+      }
+      return;
+    }
+
+    // Leaf page: show its title and description (uniform).
+    await this._core.append(node.title ?? node.name, 0.2, CommandType.title);
+    await this._core.append(node.description ?? "(no description)", 0.2, CommandType.logdata);
   }
 
   async firstUpdated() {

--- a/v2-blog/src/components/terminal-overlay.ts
+++ b/v2-blog/src/components/terminal-overlay.ts
@@ -8,9 +8,10 @@ import {
   buildTree,
   fetchSiteIndex,
   findNode,
-  matchEntry,
   renderRootListing,
   renderSubtree,
+  resolveOpen,
+  sanitizeNavQuery,
 } from "../_helpers/terminal/site-index.ts";
 
 /**
@@ -212,27 +213,33 @@ export class TerminalOverlay extends LitElement {
 
       open: async (ctx: ParsedCommand) => {
         await this._core.append(ctx.raw, 0.2, CommandType.command);
-        const query = ctx.positionals.join(" ");
+        const query = sanitizeNavQuery(ctx.positionals.join(" "));
         if (!query) {
-          await this._core.append("usage: open <slug>", 0.2, CommandType.error);
+          await this._core.append("usage: open <slug-or-path>", 0.2, CommandType.error);
           return;
         }
 
         const entries = await fetchSiteIndex();
-        const result = matchEntry(entries, query);
+        const result = resolveOpen(buildTree(entries), entries, query);
 
-        if (result.kind === "match") {
-          await this._core.append(`opening ${result.entry.title}...`, 0.2, CommandType.status);
-          window.location.href = result.entry.url;
-        } else if (result.kind === "ambiguous") {
-          await this._core.append(`"${query}" is ambiguous — did you mean:`, 0.2, CommandType.error);
-          await this._core.append(
-            result.entries.map((e) => `  ${e.title}`).join("\n"),
-            0.2,
-            CommandType.logdata
-          );
-        } else {
-          await this._core.append(`no match for "${query}"`, 0.2, CommandType.error);
+        switch (result.kind) {
+          case "navigate":
+            await this._core.append(`opening ${result.title}...`, 0.2, CommandType.status);
+            window.location.href = result.url;
+            break;
+          case "ambiguous":
+            await this._core.append(`"${query}" is ambiguous — did you mean:`, 0.2, CommandType.error);
+            await this._core.append(
+              result.entries.map((e) => `  ${e.title}`).join("\n"),
+              0.2,
+              CommandType.logdata
+            );
+            break;
+          case "not-a-page":
+            await this._core.append(`${query} is a folder, not a page — try: ls ${query}`, 0.2, CommandType.error);
+            break;
+          default:
+            await this._core.append(`no match for "${query}"`, 0.2, CommandType.error);
         }
       },
     },
@@ -254,7 +261,7 @@ export class TerminalOverlay extends LitElement {
     await this._core.append(ctx.raw, 0.2, CommandType.command);
 
     const root = buildTree(await fetchSiteIndex());
-    const target = ctx.positionals[0];
+    const target = sanitizeNavQuery(ctx.positionals[0] ?? "");
 
     if (!target) {
       for (const line of renderRootListing(root)) {

--- a/v2-blog/src/components/terminal-overlay.ts
+++ b/v2-blog/src/components/terminal-overlay.ts
@@ -4,6 +4,7 @@ import { adoptTailwind } from "../_helpers/styleLoader.ts";
 import { animator } from "../_helpers/animationManager.ts";
 import { CommandType, TerminalCore } from "../_helpers/terminal/core.ts";
 import type { ParsedCommand } from "../_helpers/terminal/parser.ts";
+import { fetchSiteIndex, filterSection, matchEntry } from "../_helpers/terminal/site-index.ts";
 
 /**
  * Site-wide summonable terminal overlay (the "cheat console").
@@ -193,16 +194,68 @@ export class TerminalOverlay extends LitElement {
       help: async (ctx: ParsedCommand) => {
         await this._core.append(ctx.raw, 0.2, CommandType.command);
         await this._core.append(
-          "help - list commands\nmore commands coming soon",
+          "help - list commands\nls [section] - list site content (posts, books, pages)\nopen <slug> - go to a page",
           0.3,
           CommandType.logdata
         );
+      },
+
+      ls: async (ctx: ParsedCommand) => this._listContent(ctx),
+      list: async (ctx: ParsedCommand) => this._listContent(ctx),
+
+      open: async (ctx: ParsedCommand) => {
+        await this._core.append(ctx.raw, 0.2, CommandType.command);
+        const query = ctx.positionals.join(" ");
+        if (!query) {
+          await this._core.append("usage: open <slug>", 0.2, CommandType.error);
+          return;
+        }
+
+        const entries = await fetchSiteIndex();
+        const result = matchEntry(entries, query);
+
+        if (result.kind === "match") {
+          await this._core.append(`opening ${result.entry.title}...`, 0.2, CommandType.status);
+          window.location.href = result.entry.url;
+        } else if (result.kind === "ambiguous") {
+          await this._core.append(`"${query}" is ambiguous — did you mean:`, 0.2, CommandType.error);
+          await this._core.append(
+            result.entries.map((e) => `  ${e.title}`).join("\n"),
+            0.2,
+            CommandType.logdata
+          );
+        } else {
+          await this._core.append(`no match for "${query}"`, 0.2, CommandType.error);
+        }
       },
     },
     logEl: () => this._log,
     skipAnimations: () => this._skipAnimations,
     onLineWritten: () => this._scrollToBottom(),
   });
+
+  /**
+   * Lists site content for `ls` / `list [section]`, optionally filtered.
+   *
+   * @param ctx - The parsed command (first positional is an optional section).
+   * @returns A promise that settles once the listing is written.
+   */
+  private async _listContent(ctx: ParsedCommand): Promise<void> {
+    await this._core.append(ctx.raw, 0.2, CommandType.command);
+
+    const section = ctx.positionals[0];
+    const entries = filterSection(await fetchSiteIndex(), section);
+
+    if (entries.length === 0) {
+      await this._core.append(section ? `nothing in "${section}"` : "nothing to list", 0.2, CommandType.error);
+      return;
+    }
+
+    await this._core.append(section ? section : "all content", 0.2, CommandType.title);
+    for (const entry of entries) {
+      await this._core.append(`  ${entry.title}`, 0.05, CommandType.logdata);
+    }
+  }
 
   async firstUpdated() {
     try {

--- a/v2-blog/src/site-index.11ty.js
+++ b/v2-blog/src/site-index.11ty.js
@@ -1,0 +1,43 @@
+// Build-time site index for the terminal `ls` / `open` commands.
+// Emits /assets/site-index.json from the published collections. Drafts and
+// future-dated content are already excluded by `published` / `books`.
+// Individual notes have no pages (permalink:false) and are intentionally omitted;
+// the /notes/ listing is included as a page.
+
+const PAGES = [
+  { title: "Home", url: "/" },
+  { title: "Blog", url: "/blog/" },
+  { title: "Notes", url: "/notes/" },
+  { title: "Books", url: "/books/" },
+  { title: "About", url: "/about/" },
+  { title: "Games", url: "/games/" },
+  { title: "Copyright", url: "/copyright/" },
+];
+
+export const data = {
+  permalink: "/assets/site-index.json",
+  eleventyExcludeFromCollections: true,
+};
+
+export function render({ collections }) {
+  const entries = [];
+
+  for (const post of collections.published || []) {
+    entries.push({
+      section: "posts",
+      title: post.data.title,
+      url: post.url,
+      date: post.date ? new Date(post.date).toISOString() : undefined,
+    });
+  }
+
+  for (const book of collections.books || []) {
+    entries.push({ section: "books", title: book.data.title, url: book.url });
+  }
+
+  for (const page of PAGES) {
+    entries.push({ section: "pages", title: page.title, url: page.url });
+  }
+
+  return JSON.stringify(entries);
+}

--- a/v2-blog/src/site-index.11ty.js
+++ b/v2-blog/src/site-index.11ty.js
@@ -1,18 +1,9 @@
 // Build-time site index for the terminal `ls` / `open` commands.
-// Emits /assets/site-index.json from the published collections. Drafts and
-// future-dated content are already excluded by `published` / `books`.
-// Individual notes have no pages (permalink:false) and are intentionally omitted;
-// the /notes/ listing is included as a page.
-
-const PAGES = [
-  { title: "Home", url: "/" },
-  { title: "Blog", url: "/blog/" },
-  { title: "Notes", url: "/notes/" },
-  { title: "Books", url: "/books/" },
-  { title: "About", url: "/about/" },
-  { title: "Games", url: "/games/" },
-  { title: "Copyright", url: "/copyright/" },
-];
+// Emits /assets/site-index.json from the published collections plus the
+// top-level pages collection. Every URL comes from the real Eleventy
+// permalink (never hardcoded). Drafts and future-dated content are excluded
+// by `published` / `books`. Individual notes have no pages (permalink:false)
+// and are intentionally omitted; the /notes/ listing is a page.
 
 export const data = {
   permalink: "/assets/site-index.json",
@@ -24,19 +15,30 @@ export function render({ collections }) {
 
   for (const post of collections.published || []) {
     entries.push({
-      section: "posts",
+      section: "blog",
       title: post.data.title,
       url: post.url,
       date: post.date ? new Date(post.date).toISOString() : undefined,
+      description: post.data.description,
     });
   }
 
   for (const book of collections.books || []) {
-    entries.push({ section: "books", title: book.data.title, url: book.url });
+    entries.push({
+      section: "books",
+      title: book.data.title,
+      url: book.url,
+      description: book.data.description,
+    });
   }
 
-  for (const page of PAGES) {
-    entries.push({ section: "pages", title: page.title, url: page.url });
+  for (const page of collections.pages || []) {
+    entries.push({
+      section: "pages",
+      title: page.data.title,
+      url: page.url,
+      description: page.data.description,
+    });
   }
 
   return JSON.stringify(entries);

--- a/v2-blog/tests/e2e/terminal-overlay.spec.ts
+++ b/v2-blog/tests/e2e/terminal-overlay.spec.ts
@@ -32,10 +32,15 @@ test("ls lists content and open navigates to a post", async ({ page }) => {
   const input = page.locator("#overlay-input");
   await expect(input).toBeFocused();
 
-  // ls lists site content.
+  // ls shows the top-level tree (folders with counts).
   await input.fill("ls");
   await page.keyboard.press("Enter");
-  await expect(page.locator("#overlay-log")).toContainText("Ngrok");
+  await expect(page.locator("#overlay-log")).toContainText("blog/");
+
+  // drilling into a folder shows its tree of slugs.
+  await input.fill("ls blog");
+  await page.keyboard.press("Enter");
+  await expect(page.locator("#overlay-log")).toContainText("using-ngrok-to-test-some-web-things");
 
   // open navigates to the matching post.
   await input.fill("open ngrok");

--- a/v2-blog/tests/e2e/terminal-overlay.spec.ts
+++ b/v2-blog/tests/e2e/terminal-overlay.spec.ts
@@ -25,6 +25,25 @@ test("Ctrl+Shift+C summons the overlay, runs help, and Esc closes it", async ({ 
   await expect(overlay).not.toHaveAttribute("open", "");
 });
 
+test("ls lists content and open navigates to a post", async ({ page }) => {
+  await page.goto("/");
+  await page.keyboard.press("Control+Shift+C");
+
+  const input = page.locator("#overlay-input");
+  await expect(input).toBeFocused();
+
+  // ls lists site content.
+  await input.fill("ls");
+  await page.keyboard.press("Enter");
+  await expect(page.locator("#overlay-log")).toContainText("Ngrok");
+
+  // open navigates to the matching post.
+  await input.fill("open ngrok");
+  await page.keyboard.press("Enter");
+  await page.waitForURL("**/blog/2025/using-ngrok-to-test-some-web-things/");
+  await expect(page.getByRole("heading", { level: 1 })).toContainText("Ngrok");
+});
+
 test("the overlay is not summonable on the books terminal page", async ({ page }) => {
   await page.goto("/books/");
   await page.keyboard.press("Control+Shift+C");

--- a/v2-blog/tests/unit/helpers/terminal/site-index.test.ts
+++ b/v2-blog/tests/unit/helpers/terminal/site-index.test.ts
@@ -127,6 +127,20 @@ describe("findNode", () => {
 
     expect(findNode(root, "nope")).toBeUndefined();
   });
+
+  it("resolves a slash-separated path by walking segments from the root", () => {
+    const root = buildTree(ENTRIES);
+
+    const year = findNode(root, "blog/2025");
+    expect(year?.name).toBe("2025");
+    expect(year!.count).toBe(3);
+
+    const leaf = findNode(root, "books/ring");
+    expect(leaf?.url).toBe("/books/ring/");
+
+    // a wrong path segment fails cleanly
+    expect(findNode(root, "blog/1999")).toBeUndefined();
+  });
 });
 
 describe("renderRootListing", () => {

--- a/v2-blog/tests/unit/helpers/terminal/site-index.test.ts
+++ b/v2-blog/tests/unit/helpers/terminal/site-index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { buildTree, findNode, matchEntry, parseSiteIndex, renderRootListing, renderSubtree } from "../../../../src/_helpers/terminal/site-index.ts";
+import { buildTree, findNode, matchEntry, parseSiteIndex, renderRootListing, renderSubtree, resolveOpen, sanitizeNavQuery } from "../../../../src/_helpers/terminal/site-index.ts";
 
 const ENTRIES = parseSiteIndex([
   { section: "posts", title: "Why I never heard of Lit", url: "/blog/2025/why-i-never-heard-of-lit/" },
@@ -173,5 +173,38 @@ describe("renderSubtree", () => {
     expect(joined).toContain("├── ");             // a non-last leaf uses the tee connector
     expect(joined).toContain("why-i-never-heard-of-lit");
     expect(lines.some((l) => l.includes("└── test-driven-fun"))).toBe(true); // last leaf, corner
+  });
+});
+
+describe("sanitizeNavQuery", () => {
+  it("strips disallowed characters, collapses separators, trims and caps length", () => {
+    expect(sanitizeNavQuery("  Blog/2025  ")).toBe("blog/2025");
+    expect(sanitizeNavQuery("books//ring")).toBe("books/ring");
+    expect(sanitizeNavQuery("ring<script>alert(1)</script>")).toBe("ringscriptalert1/script");
+    expect(sanitizeNavQuery("../../etc/passwd")).toBe("etc/passwd");
+    expect(sanitizeNavQuery("a".repeat(500)).length).toBeLessThanOrEqual(120);
+  });
+});
+
+describe("resolveOpen", () => {
+  const root = buildTree(ENTRIES);
+
+  it("navigates to a leaf reached by a slash path", () => {
+    const r = resolveOpen(root, ENTRIES, "books/ring");
+    expect(r).toEqual({ kind: "navigate", url: "/books/ring/", title: "Ring" });
+  });
+
+  it("reports not-a-page for a path that lands on a page-less folder (e.g. a year)", () => {
+    expect(resolveOpen(root, ENTRIES, "blog/2025").kind).toBe("not-a-page");
+  });
+
+  it("reports none for an unresolvable path", () => {
+    expect(resolveOpen(root, ENTRIES, "blog/9999").kind).toBe("none");
+  });
+
+  it("falls back to slug/title matching for a bare query (navigate / ambiguous / none)", () => {
+    expect(resolveOpen(root, ENTRIES, "ngrok")).toMatchObject({ kind: "navigate", url: "/blog/2025/using-ngrok-to-test-some-web-things/" });
+    expect(resolveOpen(root, ENTRIES, "test").kind).toBe("ambiguous");
+    expect(resolveOpen(root, ENTRIES, "zzz").kind).toBe("none");
   });
 });

--- a/v2-blog/tests/unit/helpers/terminal/site-index.test.ts
+++ b/v2-blog/tests/unit/helpers/terminal/site-index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { filterSection, matchEntry, parseSiteIndex } from "../../../../src/_helpers/terminal/site-index.ts";
+import { buildTree, findNode, matchEntry, parseSiteIndex, renderRootListing, renderSubtree } from "../../../../src/_helpers/terminal/site-index.ts";
 
 const ENTRIES = parseSiteIndex([
   { section: "posts", title: "Why I never heard of Lit", url: "/blog/2025/why-i-never-heard-of-lit/" },
@@ -36,12 +36,13 @@ describe("parseSiteIndex", () => {
     expect(parseSiteIndex(null)).toEqual([]);
   });
 
-  it("ignores unknown extra fields without breaking (forward-compatible)", () => {
+  it("keeps description and ignores other unknown fields (forward-compatible)", () => {
     const entries = parseSiteIndex([
-      { section: "posts", title: "T", url: "/blog/x/", description: "future search field", weight: 5 },
+      { section: "posts", title: "T", url: "/blog/x/", description: "a summary", weight: 5 },
     ]);
 
-    expect(entries[0]).toMatchObject({ section: "posts", title: "T", url: "/blog/x/" });
+    expect(entries[0]).toMatchObject({ section: "posts", title: "T", url: "/blog/x/", description: "a summary" });
+    expect(entries[0]).not.toHaveProperty("weight");
   });
 });
 
@@ -74,18 +75,89 @@ describe("matchEntry", () => {
   });
 });
 
-describe("filterSection", () => {
-  it("returns all entries when no section is given", () => {
-    expect(filterSection(ENTRIES)).toHaveLength(ENTRIES.length);
-  });
+describe("buildTree", () => {
+  it("groups entries into a tree by URL path segments", () => {
+    const root = buildTree(ENTRIES);
 
-  it("returns only the requested section, case-insensitively", () => {
-    const books = filterSection(ENTRIES, "BOOKS");
-    expect(books.length).toBe(2);
-    expect(books.every((e) => e.section === "books")).toBe(true);
-  });
+    const blog = root.children.find((n) => n.name === "blog");
+    expect(blog).toBeDefined();
+    expect(blog!.children.find((n) => n.name === "2025")).toBeDefined();
 
-  it("returns empty for an unknown section", () => {
-    expect(filterSection(ENTRIES, "widgets")).toEqual([]);
+    const books = root.children.find((n) => n.name === "books");
+    expect(books!.children.map((n) => n.name).sort()).toEqual(["a-seca", "ring"]);
+
+    const about = root.children.find((n) => n.name === "about");
+    expect(about!.children).toHaveLength(0);
+  });
+});
+
+describe("buildTree counts", () => {
+  it("sets each folder's count to its descendant leaf pages, recursively", () => {
+    const root = buildTree(ENTRIES);
+    const find = (name: string) => root.children.find((n) => n.name === name)!;
+
+    expect(find("blog").count).toBe(3);
+    expect(find("blog").children.find((n) => n.name === "2025")!.count).toBe(3);
+    expect(find("books").count).toBe(2);
+    expect(find("about").count).toBe(0);
+  });
+});
+
+describe("buildTree home + findNode", () => {
+  it("places the home page (url '/') as a root leaf named 'home'", () => {
+    const root = buildTree(parseSiteIndex([{ section: "pages", title: "Home", url: "/" }]));
+    const home = root.children.find((n) => n.name === "home");
+    expect(home).toBeDefined();
+    expect(home!.url).toBe("/");
+    expect(home!.children).toHaveLength(0);
+  });
+});
+
+describe("findNode", () => {
+  it("finds a top-level folder and a nested leaf by name, case-insensitively", () => {
+    const root = buildTree(ENTRIES);
+
+    const blog = findNode(root, "blog");
+    expect(blog?.name).toBe("blog");
+    expect(blog!.children.length).toBeGreaterThan(0);
+
+    const ring = findNode(root, "RING");
+    expect(ring?.name).toBe("ring");
+    expect(ring!.url).toBe("/books/ring/");
+
+    expect(findNode(root, "nope")).toBeUndefined();
+  });
+});
+
+describe("renderRootListing", () => {
+  it("lists folders (slash + count) before leaf pages (plain)", () => {
+    const lines = renderRootListing(buildTree(ENTRIES));
+
+    const blogLine = lines.find((l) => l.startsWith("blog/"));
+    expect(blogLine).toBeDefined();
+    expect(blogLine).toMatch(/3/);
+
+    const booksLine = lines.find((l) => l.startsWith("books/"));
+    expect(booksLine).toMatch(/2/);
+
+    // leaf page: plain name, no slash, no count
+    expect(lines).toContain("about");
+
+    // folders come before leaves
+    expect(lines.findIndex((l) => l.startsWith("blog/"))).toBeLessThan(lines.indexOf("about"));
+  });
+});
+
+describe("renderSubtree", () => {
+  it("renders a tree with connectors, sub-folder counts, and slug leaves", () => {
+    const lines = renderSubtree(findNode(buildTree(ENTRIES), "blog")!);
+    const joined = lines.join("\n");
+
+    expect(lines[0]).toMatch(/^blog/);
+    expect(joined).toContain("└── 2025");        // sole child uses the corner connector
+    expect(joined).toMatch(/2025\/?\s+3/);        // year folder shows its count
+    expect(joined).toContain("├── ");             // a non-last leaf uses the tee connector
+    expect(joined).toContain("why-i-never-heard-of-lit");
+    expect(lines.some((l) => l.includes("└── test-driven-fun"))).toBe(true); // last leaf, corner
   });
 });

--- a/v2-blog/tests/unit/helpers/terminal/site-index.test.ts
+++ b/v2-blog/tests/unit/helpers/terminal/site-index.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import { filterSection, matchEntry, parseSiteIndex } from "../../../../src/_helpers/terminal/site-index.ts";
+
+const ENTRIES = parseSiteIndex([
+  { section: "posts", title: "Why I never heard of Lit", url: "/blog/2025/why-i-never-heard-of-lit/" },
+  { section: "posts", title: "Using ngrok to test some web things", url: "/blog/2025/using-ngrok-to-test-some-web-things/" },
+  { section: "posts", title: "Test driven fun", url: "/blog/2025/test-driven-fun/" },
+  { section: "books", title: "Ring", url: "/books/ring/" },
+  { section: "books", title: "A Seca", url: "/books/a-seca/" },
+  { section: "pages", title: "About", url: "/about/" },
+]);
+
+describe("parseSiteIndex", () => {
+  it("keeps well-formed entries", () => {
+    const entries = parseSiteIndex([
+      { section: "posts", title: "Why I never heard of Lit", url: "/blog/2025/why-i-never-heard-of-lit/" },
+      { section: "books", title: "Ring", url: "/books/ring/" },
+    ]);
+
+    expect(entries).toHaveLength(2);
+    expect(entries[0]).toMatchObject({ section: "posts", title: "Why I never heard of Lit", url: "/blog/2025/why-i-never-heard-of-lit/" });
+  });
+
+  it("drops entries missing a url or title, and ignores non-array input", () => {
+    const entries = parseSiteIndex([
+      { section: "books", title: "Ring", url: "/books/ring/" },
+      { section: "posts", title: "No url" },
+      { section: "posts", url: "/blog/x/" },
+      null,
+    ]);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].title).toBe("Ring");
+    expect(parseSiteIndex("nope")).toEqual([]);
+    expect(parseSiteIndex(null)).toEqual([]);
+  });
+
+  it("ignores unknown extra fields without breaking (forward-compatible)", () => {
+    const entries = parseSiteIndex([
+      { section: "posts", title: "T", url: "/blog/x/", description: "future search field", weight: 5 },
+    ]);
+
+    expect(entries[0]).toMatchObject({ section: "posts", title: "T", url: "/blog/x/" });
+  });
+});
+
+describe("matchEntry", () => {
+  it("matches an exact url slug", () => {
+    const result = matchEntry(ENTRIES, "ring");
+    expect(result.kind).toBe("match");
+    if (result.kind === "match") expect(result.entry.url).toBe("/books/ring/");
+  });
+
+  it("matches a single partial (slug or title), case-insensitively", () => {
+    const bySlug = matchEntry(ENTRIES, "NGROK");
+    expect(bySlug.kind).toBe("match");
+    if (bySlug.kind === "match") expect(bySlug.entry.url).toBe("/blog/2025/using-ngrok-to-test-some-web-things/");
+
+    const byTitle = matchEntry(ENTRIES, "seca");
+    expect(byTitle.kind).toBe("match");
+    if (byTitle.kind === "match") expect(byTitle.entry.url).toBe("/books/a-seca/");
+  });
+
+  it("reports ambiguity when several entries partially match", () => {
+    const result = matchEntry(ENTRIES, "test");
+    expect(result.kind).toBe("ambiguous");
+    if (result.kind === "ambiguous") expect(result.entries.length).toBe(2);
+  });
+
+  it("reports none when nothing matches or the query is empty", () => {
+    expect(matchEntry(ENTRIES, "zzzznope").kind).toBe("none");
+    expect(matchEntry(ENTRIES, "   ").kind).toBe("none");
+  });
+});
+
+describe("filterSection", () => {
+  it("returns all entries when no section is given", () => {
+    expect(filterSection(ENTRIES)).toHaveLength(ENTRIES.length);
+  });
+
+  it("returns only the requested section, case-insensitively", () => {
+    const books = filterSection(ENTRIES, "BOOKS");
+    expect(books.length).toBe(2);
+    expect(books.every((e) => e.section === "books")).toBe(true);
+  });
+
+  it("returns empty for an unknown section", () => {
+    expect(filterSection(ENTRIES, "widgets")).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #78.

## What changed

The overlay terminal can now navigate the site.

- **Build-time index** — a JS Eleventy template emits `/assets/site-index.json` from the `published` (posts) and `books` collections plus the top-level pages (home, blog, notes-listing, books-listing, about, games, copyright). Drafts and future-dated content are excluded by the collections; individual notes are omitted (they have no pages — `permalink: false`).
- **`ls` / `list [section]`** — lists site content, optionally filtered to `posts` / `books` / `pages`.
- **`open <slug>`** — resolves the query (exact slug → single partial on slug/title → ambiguous → none) and navigates, with a helpful message instead of navigating when ambiguous or unmatched.
- The index is fetched lazily and coalesced (once per page load); `help` documents the new commands.

The index format tolerates unknown fields, leaving room for the v2 full-text search (descriptions etc.) without breaking consumers.

## Tests & verification
- TDD: `parseSiteIndex`, `matchEntry` (exact/partial/ambiguous/none, case-insensitive), `filterSection` — **10 unit tests**; 101 total green, typecheck + lint clean, build green (manifest verified: 4 posts, 9 books, 7 pages, 0 notes).
- e2e: summon → `ls` → `open ngrok` → lands on the post.
- Verified live via the chrome-devtools MCP: `ls`, `list posts` (filtered correctly), and `open ngrok` navigating to the right post.

Part of the terminal epic (#76–#82); next up are #80 (unlock button) and #81 (chime/boot/easter eggs).