### PR TITLE
feat(terminal): session continuity across page navigation (#79)

### DIFF
--- a/v2-blog/src/_helpers/terminal/core.ts
+++ b/v2-blog/src/_helpers/terminal/core.ts
@@ -46,8 +46,12 @@ type TerminalCoreOptions = {
   skipAnimations: () => boolean;
   /** Per-line typing animation; defaults to the gsap-based typewriter. */
   typeText?: (el: HTMLElement, text: string, durationSec: number) => Promise<void>;
-  /** Invoked after each written line, e.g. to keep the log scrolled to bottom. */
-  onLineWritten?: () => void;
+  /**
+   * Invoked after each written line, e.g. to keep the log scrolled to bottom
+   * or to persist the line. Receives the line's text and kind so consumers can
+   * mirror the scrollback into storage (see the overlay's session continuity).
+   */
+  onLineWritten?: (line: { text: string; kind: CommandType }) => void;
 };
 
 /**
@@ -147,7 +151,7 @@ export class TerminalCore {
         await (this.opts.typeText ?? typeTextWithGsap)(p, line, duration);
       }
 
-      this.opts.onLineWritten?.();
+      this.opts.onLineWritten?.({ text: line, kind });
     }
   }
 }

--- a/v2-blog/src/_helpers/terminal/history.ts
+++ b/v2-blog/src/_helpers/terminal/history.ts
@@ -19,6 +19,29 @@ export class CommandHistory {
   }
 
   /**
+   * Replaces the buffer with a saved set of entries (e.g. restored from
+   * sessionStorage) and parks the cursor past the newest, so the next ArrowUp
+   * recalls the most recent command. Non-array input is treated as empty,
+   * guarding against tampered or malformed storage.
+   *
+   * @param entries - The command lines to rehydrate, oldest first.
+   */
+  load(entries: string[]): void {
+    this.entries = Array.isArray(entries) ? [...entries] : [];
+    this.index = this.entries.length;
+  }
+
+  /**
+   * Returns the recorded commands oldest-first, for persistence across a page
+   * navigation. A defensive copy, so callers can't mutate the buffer.
+   *
+   * @returns The command lines, oldest first.
+   */
+  snapshot(): string[] {
+    return [...this.entries];
+  }
+
+  /**
    * Steps back in history (ArrowUp).
    *
    * @returns The previous command, or `undefined` when history is empty.

--- a/v2-blog/src/_helpers/terminal/session.ts
+++ b/v2-blog/src/_helpers/terminal/session.ts
@@ -1,0 +1,152 @@
+/**
+ * Session-scoped persistence for the terminal overlay: it survives full-page
+ * MPA navigations within a tab so the overlay can reopen mid-session with its
+ * scrollback and history intact (issue #79). Stored in `sessionStorage` (not
+ * local) on purpose — no ghost terminal for visitors returning days later.
+ *
+ * Deliberately dependency-free: `summon.ts`, a tiny eager script on every page,
+ * imports this to decide whether to auto-restore. Pulling in `core.ts` (and
+ * thus gsap) here would bloat that critical-path bundle, so the log-line kind
+ * is validated as a bare number range mirroring `CommandType`, not imported.
+ */
+
+/** sessionStorage key holding the serialized session snapshot. */
+export const SESSION_KEY = "book_os:session";
+
+/** Schema version; a snapshot with any other version is discarded on read. */
+export const SESSION_VERSION = 1;
+
+/** Maximum scrollback lines retained; older lines are dropped on append. */
+export const LOG_CAP = 100;
+
+/** Valid `CommandType` ordinals (log, logdata, command, title, error, status). */
+const VALID_KINDS = new Set([0, 1, 2, 3, 4, 5]);
+
+/** One persisted scrollback line: text plus its `CommandType` ordinal. */
+export interface LogLine {
+  t: string;
+  k: number;
+}
+
+/** A full terminal session snapshot persisted across a page navigation. */
+export interface SessionSnapshot {
+  v: number;
+  open: boolean;
+  history: string[];
+  log: LogLine[];
+}
+
+/** An empty, closed snapshot used as the base for the first write. */
+function emptySnapshot(): SessionSnapshot {
+  return { v: SESSION_VERSION, open: false, history: [], log: [] };
+}
+
+/**
+ * Validates an untrusted parsed payload into a snapshot. sessionStorage is
+ * user-tamperable, so any shape deviation — wrong version, non-array fields,
+ * a non-string line/history entry, or an unknown kind — discards the whole
+ * blob (returns null) rather than partially trusting it.
+ *
+ * @param raw - The `JSON.parse`d storage payload.
+ * @returns A well-formed snapshot, or null when anything is off.
+ */
+function validate(raw: unknown): SessionSnapshot | null {
+  if (!raw || typeof raw !== "object") return null;
+  const o = raw as Record<string, unknown>;
+
+  if (o.v !== SESSION_VERSION) return null;
+  if (typeof o.open !== "boolean") return null;
+  if (!Array.isArray(o.history) || !Array.isArray(o.log)) return null;
+
+  if (!o.history.every((h) => typeof h === "string")) return null;
+
+  const log: LogLine[] = [];
+  for (const line of o.log) {
+    if (!line || typeof line !== "object") return null;
+    const l = line as Record<string, unknown>;
+    if (typeof l.t !== "string" || typeof l.k !== "number" || !VALID_KINDS.has(l.k)) return null;
+    log.push({ t: l.t, k: l.k });
+  }
+
+  return { v: SESSION_VERSION, open: o.open, history: o.history as string[], log };
+}
+
+/**
+ * A thin, defensive wrapper over a `Storage` holding the terminal session.
+ * Writes are eager (read-modify-write per change) so a navigation at any
+ * instant — terminal-driven or a plain link click — already has current state.
+ */
+export class TerminalSession {
+  private storage: Storage;
+  private key: string;
+
+  /**
+   * @param storage - Backing store (defaults to `sessionStorage`).
+   * @param key - Storage key (defaults to {@link SESSION_KEY}).
+   */
+  constructor(storage: Storage = sessionStorage, key: string = SESSION_KEY) {
+    this.storage = storage;
+    this.key = key;
+  }
+
+  /**
+   * Reads and validates the stored snapshot.
+   *
+   * @returns The snapshot, or null when absent, malformed, or tampered.
+   */
+  read(): SessionSnapshot | null {
+    let raw: string | null = null;
+    try {
+      raw = this.storage.getItem(this.key);
+    } catch {
+      return null;
+    }
+    if (raw === null) return null;
+
+    try {
+      return validate(JSON.parse(raw));
+    } catch {
+      return null;
+    }
+  }
+
+  /** Sets the open flag, preserving history and log. */
+  setOpen(open: boolean): void {
+    const snap = this.read() ?? emptySnapshot();
+    snap.open = open;
+    this.write(snap);
+  }
+
+  /** Replaces the recall history, preserving the open flag and log. */
+  setHistory(history: string[]): void {
+    const snap = this.read() ?? emptySnapshot();
+    snap.history = Array.isArray(history) ? [...history] : [];
+    this.write(snap);
+  }
+
+  /** Appends a scrollback line, dropping the oldest beyond {@link LOG_CAP}. */
+  appendLine(t: string, k: number): void {
+    const snap = this.read() ?? emptySnapshot();
+    snap.log.push({ t, k });
+    if (snap.log.length > LOG_CAP) snap.log = snap.log.slice(-LOG_CAP);
+    this.write(snap);
+  }
+
+  /** Removes the stored session (e.g. on close). */
+  clear(): void {
+    try {
+      this.storage.removeItem(this.key);
+    } catch {
+      // storage unavailable (private mode quota, etc.) — nothing to clear
+    }
+  }
+
+  /** Serializes a snapshot to storage, swallowing quota/availability errors. */
+  private write(snap: SessionSnapshot): void {
+    try {
+      this.storage.setItem(this.key, JSON.stringify(snap));
+    } catch {
+      // storage full or unavailable — continuity is best-effort, never fatal
+    }
+  }
+}

--- a/v2-blog/src/_helpers/terminal/summon.ts
+++ b/v2-blog/src/_helpers/terminal/summon.ts
@@ -13,6 +13,8 @@ export function matchesSummonCombo(event: KeyboardEvent): boolean {
   return (event.ctrlKey || event.metaKey) && event.shiftKey && event.code === "KeyC";
 }
 
+import { TerminalSession } from "./session.ts";
+
 /** Custom element tag for the lazily-loaded overlay. */
 const OVERLAY_TAG = "terminal-overlay";
 /** Built URL of the overlay bundle, lazy-loaded on first summon. */
@@ -59,6 +61,17 @@ export function createSummoner(target: Window = window): () => void {
   };
 
   target.addEventListener("keydown", onKeydown, true);
+
+  // Session continuity (#79): if the overlay was open when we left the previous
+  // page, re-mount it here. Deferred to idle so it never competes with the
+  // destination page's first contentful paint. The overlay self-opens and
+  // replays its scrollback during restore, so we only mount it (no open attr).
+  if (new TerminalSession().read()?.open) {
+    const schedule = target.requestIdleCallback
+      ? target.requestIdleCallback.bind(target)
+      : (cb: () => void) => target.setTimeout(cb, 50);
+    schedule(() => ensureOverlay());
+  }
 
   return () => target.removeEventListener("keydown", onKeydown, true);
 }

--- a/v2-blog/src/components/terminal-overlay.ts
+++ b/v2-blog/src/components/terminal-overlay.ts
@@ -13,6 +13,7 @@ import {
   resolveOpen,
   sanitizeNavQuery,
 } from "../_helpers/terminal/site-index.ts";
+import { TerminalSession } from "../_helpers/terminal/session.ts";
 
 /**
  * Site-wide summonable terminal overlay (the "cheat console").
@@ -197,6 +198,20 @@ export class TerminalOverlay extends LitElement {
   private _skipAnimations =
     window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches ?? false;
 
+  /** Session-scoped continuity store (survives full-page navigations). */
+  private _session = new TerminalSession();
+  /** True while replaying restored scrollback, to suppress re-persisting it. */
+  private _restoring = false;
+  /** When set, the next open settles in place instead of sliding (restore). */
+  private _skipSlideOnce = false;
+  /** Resolves once any session restore on mount has finished (test hook). */
+  private _restoreComplete: Promise<void> | null = null;
+
+  /** Awaitable that settles after a mount-time session restore completes. */
+  get restoreComplete(): Promise<void> | null {
+    return this._restoreComplete;
+  }
+
   private _core = new TerminalCore({
     commands: {
       help: async (ctx: ParsedCommand) => {
@@ -245,7 +260,11 @@ export class TerminalOverlay extends LitElement {
     },
     logEl: () => this._log,
     skipAnimations: () => this._skipAnimations,
-    onLineWritten: () => this._scrollToBottom(),
+    onLineWritten: (line) => {
+      this._scrollToBottom();
+      // Mirror live output into the session; restore replay is already stored.
+      if (!this._restoring) this._session.appendLine(line.text, line.kind);
+    },
   });
 
   /**
@@ -289,6 +308,9 @@ export class TerminalOverlay extends LitElement {
   }
 
   async firstUpdated() {
+    // Kick off restore synchronously (before the async style load) so the
+    // replay isn't gated on Tailwind and `restoreComplete` is set immediately.
+    this._restoreComplete = this._maybeRestore();
     try {
       await adoptTailwind(this.renderRoot as ShadowRoot, "terminal-overlay-shadow.css");
     } catch (e) {
@@ -296,12 +318,44 @@ export class TerminalOverlay extends LitElement {
     }
   }
 
+  /**
+   * Restores a continued session on mount: if the stored snapshot was left
+   * open, replays its scrollback instantly, rehydrates history, reopens without
+   * sliding, and prints a `cd ~<path>` arrival line for the new page.
+   *
+   * @returns A promise that settles once restore (if any) has finished.
+   */
+  private async _maybeRestore(): Promise<void> {
+    const snap = this._session.read();
+    if (!snap || !snap.open) return;
+
+    this._restoring = true;
+    for (const line of snap.log) {
+      await this._core.append(line.t, 0, line.k);
+    }
+    this._restoring = false;
+
+    this._core.history.load(snap.history);
+
+    this._skipSlideOnce = true;
+    this.open = true;
+    await this.updateComplete;
+
+    const path = window.location.pathname.replace(/\/+$/, "");
+    await this._core.append(`cd ~${path}`, 0, CommandType.status);
+  }
+
   protected updated(changed: PropertyValues): void {
     if (changed.has("open")) {
       if (this.open) {
         this._onOpened();
+        this._session.setOpen(true);
       } else {
-        this._onClosed(changed.get("open") as boolean | undefined);
+        const wasOpen = changed.get("open") as boolean | undefined;
+        this._onClosed(wasOpen);
+        // Only a real close ends the session; the initial render (wasOpen
+        // undefined) must not wipe a session we're about to restore.
+        if (wasOpen) this._session.clear();
       }
     }
   }
@@ -315,6 +369,14 @@ export class TerminalOverlay extends LitElement {
     this._showPopover();
     this._restoreFocusTo = document.activeElement;
     this._input?.focus();
+
+    // A continuity restore appears already-open: settle in place, no slide.
+    if (this._skipSlideOnce) {
+      this._skipSlideOnce = false;
+      if (this._panel) this._panel.style.transform = "translateY(0)";
+      return;
+    }
+
     void this._slide(true);
   }
 
@@ -391,7 +453,25 @@ export class TerminalOverlay extends LitElement {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       this._form?.requestSubmit();
+      return;
     }
+
+    if (e.key === "ArrowUp" || e.key === "ArrowDown") {
+      e.preventDefault();
+      this._recallHistory(e.key);
+    }
+  }
+
+  /**
+   * Steps through command history and writes the recalled line into the input.
+   *
+   * @param key - ArrowUp steps back, ArrowDown steps forward.
+   * @returns `void`.
+   */
+  private _recallHistory(key: "ArrowUp" | "ArrowDown"): void {
+    const value = key === "ArrowUp" ? this._core.history.prev() : this._core.history.next();
+    if (value === undefined || !this._input) return;
+    this._input.value = value;
   }
 
   /**
@@ -405,6 +485,7 @@ export class TerminalOverlay extends LitElement {
     const raw = this._input?.value ?? "";
     this._input.value = "";
     await this._core.run(raw);
+    this._session.setHistory(this._core.history.snapshot());
   }
 
   /** Keeps the log scrolled to the latest line. */

--- a/v2-blog/tests/e2e/terminal-overlay.spec.ts
+++ b/v2-blog/tests/e2e/terminal-overlay.spec.ts
@@ -54,3 +54,42 @@ test("the overlay is not summonable on the books terminal page", async ({ page }
   await page.keyboard.press("Control+Shift+C");
   await expect(page.locator("terminal-overlay")).toHaveCount(0);
 });
+
+test("session continuity: the overlay reopens with history after open navigates", async ({ page }) => {
+  await page.goto("/");
+  await page.keyboard.press("Control+Shift+C");
+
+  const input = page.locator("#overlay-input");
+  await expect(input).toBeFocused();
+
+  await input.fill("open ngrok");
+  await page.keyboard.press("Enter");
+  await page.waitForURL("**/blog/2025/using-ngrok-to-test-some-web-things/");
+
+  // The overlay re-summons itself on the destination (after paint, on idle).
+  const overlay = page.locator("terminal-overlay");
+  await expect(overlay).toHaveAttribute("open", "", { timeout: 10000 });
+
+  // Scrollback replayed + a cd-style arrival line for the new path.
+  await expect(page.locator("#overlay-log")).toContainText(
+    "cd ~/blog/2025/using-ngrok-to-test-some-web-things"
+  );
+
+  // Arrow-up recalls the command issued before the jump.
+  await input.focus();
+  await page.keyboard.press("ArrowUp");
+  await expect(input).toHaveValue("open ngrok");
+});
+
+test("closing the overlay then navigating normally does not resurrect it", async ({ page }) => {
+  await page.goto("/");
+  await page.keyboard.press("Control+Shift+C");
+  await expect(page.locator("terminal-overlay")).toHaveAttribute("open", "");
+
+  await page.keyboard.press("Escape");
+  await expect(page.locator("terminal-overlay")).not.toHaveAttribute("open", "");
+
+  await page.goto("/about/");
+  // A normal navigation after closing must not bring the overlay back.
+  await expect(page.locator("terminal-overlay")).toHaveCount(0);
+});

--- a/v2-blog/tests/unit/components/terminal-overlay.test.ts
+++ b/v2-blog/tests/unit/components/terminal-overlay.test.ts
@@ -23,6 +23,7 @@ vi.mock("../../../src/_helpers/animationManager.ts", () => ({
 }));
 
 import { TerminalOverlay } from "../../../src/components/terminal-overlay.ts";
+import { TerminalSession } from "../../../src/_helpers/terminal/session.ts";
 
 async function mountOverlay() {
   const el = new TerminalOverlay();
@@ -40,6 +41,7 @@ function submit(el: TerminalOverlay, value: string) {
 
 beforeEach(() => {
   document.body.innerHTML = "";
+  sessionStorage.clear();
   animatorMock.cancel.mockClear();
   animatorMock.animate.mockClear();
 });
@@ -129,5 +131,137 @@ describe("terminal-overlay", () => {
     await el.updateComplete;
 
     expect(animatorMock.animate).toHaveBeenCalledTimes(1);
+  });
+
+  describe("history recall", () => {
+    async function pressArrow(el: TerminalOverlay, key: "ArrowUp" | "ArrowDown") {
+      const input = el.shadowRoot!.querySelector<HTMLTextAreaElement>("#overlay-input")!;
+      const event = new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true });
+      input.dispatchEvent(event);
+      await el.updateComplete;
+      return event;
+    }
+
+    it("recalls the previous command into the input on ArrowUp and prevents the default", async () => {
+      const el = await mountOverlay();
+      el.open = true;
+      await el.updateComplete;
+
+      submit(el, "help");
+      await el.updateComplete;
+      await Promise.resolve();
+
+      const event = await pressArrow(el, "ArrowUp");
+
+      const input = el.shadowRoot!.querySelector<HTMLTextAreaElement>("#overlay-input")!;
+      expect(input.value).toBe("help");
+      expect(event.defaultPrevented).toBe(true);
+    });
+
+    it("steps back through several commands and forward again with ArrowDown", async () => {
+      const el = await mountOverlay();
+      el.open = true;
+      await el.updateComplete;
+
+      submit(el, "help");
+      await el.updateComplete;
+      await Promise.resolve();
+      submit(el, "ls");
+      await el.updateComplete;
+      await Promise.resolve();
+
+      const input = el.shadowRoot!.querySelector<HTMLTextAreaElement>("#overlay-input")!;
+
+      await pressArrow(el, "ArrowUp");
+      expect(input.value).toBe("ls");
+      await pressArrow(el, "ArrowUp");
+      expect(input.value).toBe("help");
+
+      await pressArrow(el, "ArrowDown");
+      expect(input.value).toBe("ls");
+      await pressArrow(el, "ArrowDown");
+      expect(input.value).toBe("");
+    });
+  });
+
+  describe("session continuity", () => {
+    it("persists the open flag while open and clears the session on close", async () => {
+      const el = await mountOverlay();
+
+      el.open = true;
+      await el.updateComplete;
+      expect(new TerminalSession().read()?.open).toBe(true);
+
+      el.open = false;
+      await el.updateComplete;
+      expect(new TerminalSession().read()).toBeNull();
+    });
+
+    it("does not clear the session on the initial (never-opened) render", async () => {
+      new TerminalSession().setOpen(true);
+
+      await mountOverlay(); // open defaults to false; must not wipe an existing session
+
+      // a restore will have re-asserted open:true; the key must still exist
+      expect(new TerminalSession().read()).not.toBeNull();
+    });
+
+    it("mirrors written log lines and command history into the session", async () => {
+      const el = await mountOverlay();
+      el.open = true;
+      await el.updateComplete;
+
+      submit(el, "help");
+      // help appends several lines sequentially; persistence (onLineWritten)
+      // trails the synchronous DOM write by a microtask per line — drain them.
+      for (let i = 0; i < 12; i++) await Promise.resolve();
+
+      const snap = new TerminalSession().read()!;
+      expect(snap.log.some((l) => l.t.includes("help - list commands"))).toBe(true);
+      expect(snap.history).toContain("help");
+    });
+
+    it("restores scrollback, history and an arrival line, opening without a slide", async () => {
+      const seed = new TerminalSession();
+      seed.setOpen(true);
+      seed.appendLine("$ ls", 2);
+      seed.appendLine("blog/   3", 0);
+      seed.setHistory(["ls"]);
+
+      const el = new TerminalOverlay();
+      document.body.appendChild(el);
+      await el.updateComplete;
+      await el.restoreComplete;
+      await el.updateComplete;
+
+      // reopened
+      expect(el.open).toBe(true);
+      // scrollback replayed
+      const log = el.shadowRoot!.querySelector("#overlay-log")!;
+      expect(log.textContent).toContain("blog/   3");
+      // arrival line (status-kind cd ~<path>)
+      expect(log.textContent).toContain("cd ~");
+      // history rehydrated → ArrowUp recalls the pre-jump command
+      const input = el.shadowRoot!.querySelector<HTMLTextAreaElement>("#overlay-input")!;
+      input.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowUp", bubbles: true }));
+      await el.updateComplete;
+      expect(input.value).toBe("ls");
+      // opened instantly: no slide animation on a restore
+      expect(animatorMock.animate).not.toHaveBeenCalled();
+    });
+
+    it("does not restore when the stored session is closed", async () => {
+      const seed = new TerminalSession();
+      seed.setOpen(false);
+      seed.appendLine("stale", 0);
+
+      const el = new TerminalOverlay();
+      document.body.appendChild(el);
+      await el.updateComplete;
+      await el.restoreComplete;
+
+      expect(el.open).toBe(false);
+      expect(el.shadowRoot!.querySelector("#overlay-log")!.textContent).toBe("");
+    });
   });
 });

--- a/v2-blog/tests/unit/helpers/terminal/core.test.ts
+++ b/v2-blog/tests/unit/helpers/terminal/core.test.ts
@@ -78,6 +78,16 @@ describe("TerminalCore", () => {
     expect(logEl.querySelectorAll("p")).toHaveLength(2);
   });
 
+  it("passes each written line's text and kind to onLineWritten", async () => {
+    const onLineWritten = vi.fn();
+    const { core } = createCore({ onLineWritten });
+
+    await core.append("first\nsecond", 0, CommandType.error);
+
+    expect(onLineWritten).toHaveBeenNthCalledWith(1, { text: "first", kind: CommandType.error });
+    expect(onLineWritten).toHaveBeenNthCalledWith(2, { text: "second", kind: CommandType.error });
+  });
+
   it("records executed commands in history", async () => {
     const { core } = createCore({ commands: { list: vi.fn() } });
 

--- a/v2-blog/tests/unit/helpers/terminal/history.test.ts
+++ b/v2-blog/tests/unit/helpers/terminal/history.test.ts
@@ -52,4 +52,76 @@ describe("CommandHistory", () => {
     expect(history.prev()).toBeUndefined();
     expect(history.next()).toBeUndefined();
   });
+
+  describe("load", () => {
+    it("rehydrates the buffer and parks the cursor past the newest entry", () => {
+      const history = new CommandHistory();
+
+      history.load(["list", "book 5"]);
+
+      // cursor sits past the newest, so prev walks the loaded entries
+      expect(history.prev()).toBe("book 5");
+      expect(history.prev()).toBe("list");
+    });
+
+    it("replaces any prior entries rather than appending", () => {
+      const history = new CommandHistory();
+      history.push("stale");
+
+      history.load(["fresh"]);
+
+      expect(history.prev()).toBe("fresh");
+      expect(history.prev()).toBe("fresh");
+    });
+
+    it("clones the input so later external mutation does not leak in", () => {
+      const history = new CommandHistory();
+      const entries = ["one"];
+
+      history.load(entries);
+      entries.push("two");
+
+      expect(history.prev()).toBe("one");
+      expect(history.prev()).toBe("one");
+    });
+
+    it("ignores non-array input and tolerates an empty list", () => {
+      const history = new CommandHistory();
+      history.push("kept");
+
+      history.load([]);
+      expect(history.prev()).toBeUndefined();
+
+      // defensive against tampered storage
+      history.load(undefined as unknown as string[]);
+      expect(history.prev()).toBeUndefined();
+    });
+  });
+
+  describe("snapshot", () => {
+    it("returns the entries oldest-first as a defensive copy", () => {
+      const history = new CommandHistory();
+      history.push("list");
+      history.push("book 5");
+
+      const snap = history.snapshot();
+      expect(snap).toEqual(["list", "book 5"]);
+
+      // mutating the snapshot must not affect the buffer
+      snap.push("hack");
+      expect(history.snapshot()).toEqual(["list", "book 5"]);
+    });
+
+    it("round-trips through load", () => {
+      const a = new CommandHistory();
+      a.push("one");
+      a.push("two");
+
+      const b = new CommandHistory();
+      b.load(a.snapshot());
+
+      expect(b.prev()).toBe("two");
+      expect(b.prev()).toBe("one");
+    });
+  });
 });

--- a/v2-blog/tests/unit/helpers/terminal/session.test.ts
+++ b/v2-blog/tests/unit/helpers/terminal/session.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { LOG_CAP, SESSION_KEY, SESSION_VERSION, TerminalSession } from "../../../../src/_helpers/terminal/session.ts";
+
+/** Minimal in-memory Storage stand-in (decoupled from jsdom globals). */
+function fakeStorage(): Storage {
+  const map = new Map<string, string>();
+  return {
+    get length() {
+      return map.size;
+    },
+    clear: () => map.clear(),
+    getItem: (k) => (map.has(k) ? map.get(k)! : null),
+    key: (i) => [...map.keys()][i] ?? null,
+    removeItem: (k) => void map.delete(k),
+    setItem: (k, v) => void map.set(k, v),
+  };
+}
+
+let storage: Storage;
+let session: TerminalSession;
+
+beforeEach(() => {
+  storage = fakeStorage();
+  session = new TerminalSession(storage);
+});
+
+describe("TerminalSession", () => {
+  it("reads null when nothing has been stored", () => {
+    expect(session.read()).toBeNull();
+  });
+
+  it("persists the open flag, history and log lines, then reads them back", () => {
+    session.setOpen(true);
+    session.appendLine("$ ls", 2);
+    session.appendLine("blog/", 0);
+    session.setHistory(["ls"]);
+
+    expect(session.read()).toEqual({
+      v: SESSION_VERSION,
+      open: true,
+      history: ["ls"],
+      log: [
+        { t: "$ ls", k: 2 },
+        { t: "blog/", k: 0 },
+      ],
+    });
+  });
+
+  it("caps the log to the most recent LOG_CAP lines", () => {
+    for (let i = 0; i < LOG_CAP + 25; i++) session.appendLine(`line ${i}`, 0);
+
+    const snap = session.read()!;
+    expect(snap.log).toHaveLength(LOG_CAP);
+    expect(snap.log[0].t).toBe(`line 25`); // oldest 25 dropped
+    expect(snap.log[snap.log.length - 1].t).toBe(`line ${LOG_CAP + 24}`);
+  });
+
+  it("clear() removes the stored session", () => {
+    session.setOpen(true);
+    session.clear();
+    expect(session.read()).toBeNull();
+    expect(storage.getItem(SESSION_KEY)).toBeNull();
+  });
+
+  describe("defensive read (tampered / malformed storage)", () => {
+    const reject = (raw: string) => {
+      storage.setItem(SESSION_KEY, raw);
+      expect(session.read()).toBeNull();
+    };
+
+    it("returns null and never throws on invalid JSON", () => {
+      reject("{not json");
+    });
+
+    it("rejects a wrong or missing version", () => {
+      reject(JSON.stringify({ v: 999, open: true, history: [], log: [] }));
+      reject(JSON.stringify({ open: true, history: [], log: [] }));
+    });
+
+    it("rejects a non-boolean open flag", () => {
+      reject(JSON.stringify({ v: SESSION_VERSION, open: "yes", history: [], log: [] }));
+    });
+
+    it("rejects a non-array history or log", () => {
+      reject(JSON.stringify({ v: SESSION_VERSION, open: true, history: "ls", log: [] }));
+      reject(JSON.stringify({ v: SESSION_VERSION, open: true, history: [], log: {} }));
+    });
+
+    it("rejects a log line with a non-string text or an unknown kind", () => {
+      reject(JSON.stringify({ v: SESSION_VERSION, open: true, history: [], log: [{ t: 5, k: 0 }] }));
+      reject(JSON.stringify({ v: SESSION_VERSION, open: true, history: [], log: [{ t: "x", k: 99 }] }));
+    });
+
+    it("rejects a history entry that is not a string", () => {
+      reject(JSON.stringify({ v: SESSION_VERSION, open: true, history: [1, 2], log: [] }));
+    });
+  });
+});

--- a/v2-blog/tests/unit/helpers/terminal/summoner.test.ts
+++ b/v2-blog/tests/unit/helpers/terminal/summoner.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createSummoner } from "../../../../src/_helpers/terminal/summon.ts";
+import { TerminalSession } from "../../../../src/_helpers/terminal/session.ts";
 
 let dispose: (() => void) | undefined;
 
@@ -21,11 +22,19 @@ function pressCombo(overrides: Partial<KeyboardEvent> = {}) {
 beforeEach(() => {
   document.body.innerHTML = "";
   document.head.querySelectorAll("script").forEach((s) => s.remove());
+  sessionStorage.clear();
+  // Run idle callbacks synchronously so auto-restore is observable in tests.
+  (window as unknown as { requestIdleCallback: (cb: () => void) => number }).requestIdleCallback =
+    (cb: () => void) => {
+      cb();
+      return 0;
+    };
 });
 
 afterEach(() => {
   dispose?.();
   dispose = undefined;
+  delete (window as unknown as { requestIdleCallback?: unknown }).requestIdleCallback;
 });
 
 describe("createSummoner", () => {
@@ -75,5 +84,37 @@ describe("createSummoner", () => {
     pressCombo();
 
     expect(document.querySelector("terminal-overlay")).toBeNull();
+  });
+
+  describe("session restore", () => {
+    it("auto-mounts the overlay (and its bundle) on idle when a session was left open", () => {
+      new TerminalSession().setOpen(true);
+
+      dispose = createSummoner(window);
+
+      // mounted without any keypress; the overlay self-opens during restore,
+      // so the summoner must NOT force the open attribute itself.
+      const overlay = document.querySelector("terminal-overlay");
+      expect(overlay).not.toBeNull();
+      expect(overlay?.hasAttribute("open")).toBe(false);
+      expect(document.head.querySelector('script[src="/components/terminal-overlay.js"]')).not.toBeNull();
+    });
+
+    it("does not auto-mount when there is no session", () => {
+      dispose = createSummoner(window);
+
+      expect(document.querySelector("terminal-overlay")).toBeNull();
+      expect(document.head.querySelector('script[src="/components/terminal-overlay.js"]')).toBeNull();
+    });
+
+    it("does not auto-mount when the stored session is closed", () => {
+      const s = new TerminalSession();
+      s.setOpen(true);
+      s.setOpen(false);
+
+      dispose = createSummoner(window);
+
+      expect(document.querySelector("terminal-overlay")).toBeNull();
+    });
   });
 });


### PR DESCRIPTION
Closes #79
Closes #90

## What

Makes the terminal overlay feel like one continuous session across the MPA's full page loads. When the overlay is open and the page navigates (via \`open <slug>\` **or** a normal link), the destination re-summons it after paint — scrollback replayed, history intact, no boot — with a one-line \`cd ~<path>\` arrival message. Closing it clears the session, so a normal navigation never resurrects it.

Approach is **persist-and-reopen**, not a client-side router (decided via a grill: a router would fight the build-time per-page CSP and carry site-wide blast radius for a terminal easter-egg).

## How

- **`session.ts`** (new, intentionally dependency-free): versioned \`book_os:session\` snapshot in \`sessionStorage\` — \`{ v, open, history[], log:[{t,k}] }\`. Defensive read (bad version/shape/kind/text → discarded, never throws), 100-line log cap, eager writes. Kept free of \`core.ts\`/gsap so the eager summoner bundle stays ~1.7KB.
- **`summon.ts`**: on load, if a session was left open, re-mounts the overlay on \`requestIdleCallback\` (after first paint, no LCP/CLS competition). The overlay self-opens during restore, so the summoner only mounts it.
- **`terminal-overlay.ts`**: persists open-flag/scrollback/history (eager); on mount replays the capped scrollback instantly, rehydrates history, opens **without sliding**, and appends the \`cd ~<path>\` OK-status arrival line. Clears the session on a real close (guarded so the initial render doesn't wipe a session being restored).
- **`core.ts`**: \`onLineWritten\` now carries \`{text, kind}\` so the overlay can mirror the scrollback.
- **Folds in #90** (prereq): wires ArrowUp/ArrowDown recall in the overlay (it was missing — recall glue lives per-component, not in the shared core) and adds \`CommandHistory.load()\` / \`snapshot()\`.

## Acceptance criteria (#79)

- [x] After \`open <slug>\`, the overlay is open on the destination with prior history via arrow-up
- [x] Reopen happens after first contentful paint (idle callback); overlay is a fixed top-layer popover → no CLS
- [x] Closing then navigating normally does NOT resurrect it
- [x] History/open-state absent in a fresh session (sessionStorage, not localStorage)
- [x] One-line \`cd ~<path>\` arrival line instead of a boot sequence
- [x] e2e: summon → open a post → overlay reopened with history on the destination (+ negative case)

## Testing

- Unit: 137 pass (new: session store, \`CommandHistory.load\`/\`snapshot\`, overlay continuity + arrow-up, summoner restore). Typecheck + lint clean (0 errors).
- e2e: 5/5 (incl. both new continuity scenarios).
- Manual (chrome-devtools MCP): verified reopen + replayed scrollback + arrival line + arrow-up recall on the destination, instant (no-slide) panel, and close→navigate→no-resurrect.