### PR TITLE
feat(terminal): unlock mechanic reveals site-wide summon button (#80)

### DIFF
--- a/v2-blog/src/_helpers/terminal/summon.ts
+++ b/v2-blog/src/_helpers/terminal/summon.ts
@@ -60,7 +60,20 @@ export function createSummoner(target: Window = window): () => void {
     ensureOverlay().setAttribute("open", "");
   };
 
+  /**
+   * Opens the overlay when a `[data-terminal-summon]` trigger is clicked — the
+   * header `>_` button and its mobile-menu twin, and the only summon path on
+   * touch devices (no keyboard combo). Delegated (not an inline handler) so it
+   * stays CSP-clean.
+   */
+  const onClick = (event: MouseEvent): void => {
+    const trigger = (event.target as Element | null)?.closest?.("[data-terminal-summon]");
+    if (!trigger) return;
+    ensureOverlay().setAttribute("open", "");
+  };
+
   target.addEventListener("keydown", onKeydown, true);
+  doc.addEventListener("click", onClick);
 
   // Session continuity (#79): if the overlay was open when we left the previous
   // page, re-mount it here. Deferred to idle so it never competes with the
@@ -73,5 +86,8 @@ export function createSummoner(target: Window = window): () => void {
     schedule(() => ensureOverlay());
   }
 
-  return () => target.removeEventListener("keydown", onKeydown, true);
+  return () => {
+    target.removeEventListener("keydown", onKeydown, true);
+    doc.removeEventListener("click", onClick);
+  };
 }

--- a/v2-blog/src/_helpers/terminal/unlock.ts
+++ b/v2-blog/src/_helpers/terminal/unlock.ts
@@ -1,0 +1,42 @@
+/**
+ * The cheat-console unlock flag (issue #80). Visiting the books page — the
+ * terminal's native habitat — sets this persistent `localStorage` flag, which
+ * reveals the site-wide `>_` summon button on every page thereafter.
+ *
+ * Persistent (localStorage, not session): the discovery is meant to stick
+ * across visits. Kept dependency-free so the eager summoner and the books shell
+ * can both import it without pulling in heavier terminal code. The pre-paint
+ * boot script (`inline-terminal-unlock.js`) hardcodes the same key by necessity
+ * (it is inlined raw, not bundled) — keep them in sync.
+ */
+
+/** localStorage key holding the unlock flag. */
+export const UNLOCK_KEY = "book_os:unlocked";
+
+/**
+ * Records that the cheat console has been discovered. Best-effort: storage
+ * failures (private mode, blocked cookies) are swallowed.
+ *
+ * @param storage - Backing store (defaults to `localStorage`).
+ */
+export function markUnlocked(storage: Storage = localStorage): void {
+  try {
+    storage.setItem(UNLOCK_KEY, "1");
+  } catch {
+    // storage unavailable — the keyboard combo still works everywhere
+  }
+}
+
+/**
+ * Whether the cheat console has been unlocked.
+ *
+ * @param storage - Backing store (defaults to `localStorage`).
+ * @returns `true` once the books page has been visited.
+ */
+export function isUnlocked(storage: Storage = localStorage): boolean {
+  try {
+    return storage.getItem(UNLOCK_KEY) !== null;
+  } catch {
+    return false;
+  }
+}

--- a/v2-blog/src/_includes/css/default.css
+++ b/v2-blog/src/_includes/css/default.css
@@ -127,3 +127,21 @@ user-fakeid {
     white-space: nowrap;
   }
 }
+
+/* Cheat-console summon button (#80): hidden until the books page sets the
+   unlock flag, which the pre-paint boot script turns into html.term-unlocked.
+   Inlined here so the reveal is decided before first paint — no flash. */
+.terminal-launch {
+  display: none;
+}
+
+html.term-unlocked .terminal-launch-desktop {
+  display: none;
+  @media (width >= 768px) {
+    display: inline-flex;
+  }
+}
+
+html.term-unlocked .terminal-launch-mobile {
+  display: inline-flex;
+}

--- a/v2-blog/src/_includes/inline-terminal-unlock.js
+++ b/v2-blog/src/_includes/inline-terminal-unlock.js
@@ -1,0 +1,13 @@
+(function() {
+  // Pre-paint reveal of the cheat-console summon button (#80), mirroring the
+  // theme boot above: read the unlock flag before first paint so the button is
+  // present from the start (no flash, no layout shift). Key must match
+  // _helpers/terminal/unlock.ts (this file is inlined raw, not bundled).
+  try {
+    if (localStorage.getItem("book_os:unlocked") !== null) {
+      document.documentElement.classList.add("term-unlocked");
+    }
+  } catch (e) {
+    /* storage blocked (private mode) — the keyboard combo still works */
+  }
+})();

--- a/v2-blog/src/_includes/partials/header.njk
+++ b/v2-blog/src/_includes/partials/header.njk
@@ -55,12 +55,30 @@
               {{ link.label }}{% if isCurrentPage %}*{% endif %}
             </a>
           {% endfor %}
+
+          <button
+            type="button"
+            data-terminal-summon
+            aria-label="Open terminal console"
+            class="terminal-launch terminal-launch-mobile -translate-x-8 opacity-0 group-[[isopen]]:opacity-100 group-[[isopen]]:translate-x-0 text-5xl font-serif text-accent transition-all duration-350 delay-[900ms] items-center gap-3 cursor-pointer"
+          >
+            <span class="font-mono text-4xl">&gt;_</span>
+            console
+          </button>
         </div>
       </menu-mobile>
 
       <div class="hidden md:block w-px h-4 bg-accent/20"></div>
 
       <theme-toggle class="hidden md:flex" data-template-id="theme-toggle-tmpl"></theme-toggle>
+
+      <button
+        type="button"
+        data-terminal-summon
+        aria-label="Open terminal console"
+        title="Open terminal console (Ctrl+Shift+C)"
+        class="terminal-launch terminal-launch-desktop items-center font-mono text-base text-muted hover:text-accent transition-colors cursor-pointer"
+      >&gt;_</button>
 
     </div>
 

--- a/v2-blog/src/_layouts/base.njk
+++ b/v2-blog/src/_layouts/base.njk
@@ -20,7 +20,13 @@
 
     {% set cspScriptSrc = cspScriptSrc + " " + themeHash %}
     {% set scriptsOutput = scriptsOutput + '<script>' + (themeContent | safe | trim) + '</script>' %}
-    
+
+    {# Pre-paint reveal of the cheat-console summon button (#80) #}
+    {% set unlockContent %}{% include "inline-terminal-unlock.js" %}{% endset %}
+    {% set unlockHash = unlockContent | trim | cspHash %}
+    {% set cspScriptSrc = cspScriptSrc + " " + unlockHash %}
+    {% set scriptsOutput = scriptsOutput + '<script>' + (unlockContent | safe | trim) + '</script>' %}
+
     {# Handle optional page script #}
     {% if inlineScripts %}
       {% for path in inlineScripts %}

--- a/v2-blog/src/components/terminal-shell.ts
+++ b/v2-blog/src/components/terminal-shell.ts
@@ -10,6 +10,7 @@ import {
   type ShellAction,
   type ShellState,
 } from '../_helpers/terminal/shell-state.ts';
+import { markUnlocked } from '../_helpers/terminal/unlock.ts';
 
 @customElement('terminal-shell')
 export class TerminalShell extends LitElement {
@@ -81,7 +82,7 @@ export class TerminalShell extends LitElement {
         } else {
           await this.appendToLog("commands", 0.2, CommandType.title);
           await this.appendToLog(
-            "help/h - list command options\nlist [--all] - list the books by batch, if you want list all by flag --all",
+            "help/h - list command options\nlist [--all] - list the books by batch, if you want list all by flag --all\nctrl+shift+c - summon this console on any page of the site",
             0.5,
             CommandType.logdata
           )
@@ -208,6 +209,8 @@ export class TerminalShell extends LitElement {
 
   connectedCallback() {
     super.connectedCallback();
+    // Reaching the books terminal unlocks the site-wide cheat console (#80).
+    markUnlocked();
     // this.startBootSequence();
   }
 

--- a/v2-blog/tests/e2e/terminal-overlay.spec.ts
+++ b/v2-blog/tests/e2e/terminal-overlay.spec.ts
@@ -81,10 +81,34 @@ test("session continuity: the overlay reopens with history after open navigates"
   await expect(input).toHaveValue("open ngrok");
 });
 
+test("unlock: visiting the books page reveals the site-wide terminal button", async ({ page }) => {
+  // Fresh profile (Playwright isolates storage per test): no button, locked.
+  await page.goto("/");
+  await expect(page.locator(".terminal-launch-desktop")).toBeHidden();
+  expect(
+    await page.evaluate(() => document.documentElement.classList.contains("term-unlocked"))
+  ).toBe(false);
+
+  // Visiting the books terminal sets the persistent unlock flag.
+  await page.goto("/books/");
+  await page.waitForFunction(() => localStorage.getItem("book_os:unlocked") !== null);
+
+  // Back on a regular page the button is present (revealed pre-paint) ...
+  await page.goto("/");
+  await expect(page.locator(".terminal-launch-desktop")).toBeVisible();
+
+  // ... and summons the overlay on click.
+  await page.locator(".terminal-launch-desktop").click();
+  await expect(page.locator("terminal-overlay")).toHaveAttribute("open", "");
+});
+
 test("closing the overlay then navigating normally does not resurrect it", async ({ page }) => {
   await page.goto("/");
   await page.keyboard.press("Control+Shift+C");
   await expect(page.locator("terminal-overlay")).toHaveAttribute("open", "");
+  // Wait for the lazy bundle to upgrade the element (input focused) before
+  // Escape, otherwise the keydown handler isn't wired yet.
+  await expect(page.locator("#overlay-input")).toBeFocused();
 
   await page.keyboard.press("Escape");
   await expect(page.locator("terminal-overlay")).not.toHaveAttribute("open", "");

--- a/v2-blog/tests/unit/components/terminal-shell.test.ts
+++ b/v2-blog/tests/unit/components/terminal-shell.test.ts
@@ -47,6 +47,7 @@ vi.mock("../../../src/_helpers/identityManager.ts", () => {
 });
 
 import { TerminalShell } from "../../../src/components/terminal-shell.ts";
+import { isUnlocked } from "../../../src/_helpers/terminal/unlock.ts";
 
 function listingMarkup() {
   return `
@@ -271,5 +272,19 @@ describe("terminal-shell startup phases", () => {
     await Promise.resolve();
 
     expect(renderSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("terminal-shell unlock", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("unlocks the site-wide cheat console on connect (visiting the books page)", () => {
+    expect(isUnlocked()).toBe(false);
+
+    mountTerminalShell(listingMarkup());
+
+    expect(isUnlocked()).toBe(true);
   });
 });

--- a/v2-blog/tests/unit/helpers/terminal/summoner.test.ts
+++ b/v2-blog/tests/unit/helpers/terminal/summoner.test.ts
@@ -86,6 +86,33 @@ describe("createSummoner", () => {
     expect(document.querySelector("terminal-overlay")).toBeNull();
   });
 
+  describe("click summon (header button / mobile)", () => {
+    it("opens the overlay when an element with [data-terminal-summon] is clicked", () => {
+      const btn = document.createElement("button");
+      btn.setAttribute("data-terminal-summon", "");
+      const icon = document.createElement("span"); // click can land on a child
+      btn.appendChild(icon);
+      document.body.appendChild(btn);
+
+      dispose = createSummoner(window);
+      icon.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+      const overlay = document.querySelector("terminal-overlay");
+      expect(overlay).not.toBeNull();
+      expect(overlay?.hasAttribute("open")).toBe(true);
+    });
+
+    it("ignores clicks outside a summon trigger", () => {
+      const other = document.createElement("button");
+      document.body.appendChild(other);
+
+      dispose = createSummoner(window);
+      other.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+      expect(document.querySelector("terminal-overlay")).toBeNull();
+    });
+  });
+
   describe("session restore", () => {
     it("auto-mounts the overlay (and its bundle) on idle when a session was left open", () => {
       new TerminalSession().setOpen(true);

--- a/v2-blog/tests/unit/helpers/terminal/unlock.test.ts
+++ b/v2-blog/tests/unit/helpers/terminal/unlock.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { isUnlocked, markUnlocked, UNLOCK_KEY } from "../../../../src/_helpers/terminal/unlock.ts";
+
+/** Minimal in-memory Storage stand-in. */
+function fakeStorage(): Storage {
+  const map = new Map<string, string>();
+  return {
+    get length() {
+      return map.size;
+    },
+    clear: () => map.clear(),
+    getItem: (k) => (map.has(k) ? map.get(k)! : null),
+    key: (i) => [...map.keys()][i] ?? null,
+    removeItem: (k) => void map.delete(k),
+    setItem: (k, v) => void map.set(k, v),
+  };
+}
+
+let storage: Storage;
+
+beforeEach(() => {
+  storage = fakeStorage();
+});
+
+describe("terminal unlock flag", () => {
+  it("is locked by default", () => {
+    expect(isUnlocked(storage)).toBe(false);
+  });
+
+  it("persists the unlock and reads it back", () => {
+    markUnlocked(storage);
+    expect(storage.getItem(UNLOCK_KEY)).not.toBeNull();
+    expect(isUnlocked(storage)).toBe(true);
+  });
+
+  it("is idempotent — marking twice keeps it unlocked", () => {
+    markUnlocked(storage);
+    markUnlocked(storage);
+    expect(isUnlocked(storage)).toBe(true);
+  });
+
+  it("never throws when storage is unavailable (private mode, blocked)", () => {
+    const throwing = {
+      getItem: () => {
+        throw new Error("blocked");
+      },
+      setItem: () => {
+        throw new Error("blocked");
+      },
+    } as unknown as Storage;
+
+    expect(() => markUnlocked(throwing)).not.toThrow();
+    expect(isUnlocked(throwing)).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #80

## What

Discovery-as-progression for the cheat console. Visiting the books page (the full-page terminal's native habitat) sets a persistent unlock flag; once unlocked, a small \`>_\` button appears in the site header on every page and summons the overlay on click/tap. This is also the only summon path for touch users (the keyboard combo is desktop-only). Before unlock, regular pages show no trace of it; \`Ctrl+Shift+C\` works everywhere regardless of unlock state.

## How

- **\`unlock.ts\`** (new, dependency-free): persistent \`book_os:unlocked\` localStorage flag (\`markUnlocked\` / \`isUnlocked\`, both storage-failure-safe). Kept free of heavier terminal code so the eager summoner bundle stays small.
- **\`terminal-shell.connectedCallback\`** calls \`markUnlocked()\` — reaching the books terminal unlocks the console. Its desktop help now mentions \`ctrl+shift+c\`.
- **\`inline-terminal-unlock.js\`** (new, pre-paint): mirrors the theme boot — reads the flag before first paint and adds \`html.term-unlocked\`, so the button is present from the first frame (no flash, no layout shift). Hashed into the CSP like the other inline scripts; the key is duplicated here by necessity (inlined raw, not bundled).
- **Header** (\`header.njk\` + \`default.css\`): a \`>_\` button near the theme toggle (desktop) and a \`>_ console\` twin inside the mobile menu drawer. Both hidden by default; revealed only under \`html.term-unlocked\` via inlined CSS (so the reveal is pre-paint). Display is driven entirely by these rules — no Tailwind display utilities — since linked \`global.css\` would otherwise override the gating on specificity ties.
- **\`summon.ts\`**: a CSP-clean delegated \`click\` listener on \`[data-terminal-summon]\` opens the overlay (no inline handlers). The keyboard combo path is unchanged.

## Acceptance criteria (#80)

- [x] No terminal button anywhere before visiting the books page
- [x] After visiting books once, the header button appears on all pages and persists across sessions (localStorage)
- [x] Button summons the overlay on click and on touch devices (mobile drawer entry)
- [x] Keyboard combo works regardless of unlock state
- [x] Books terminal help mentions the combo
- [x] No visible button flash or layout shift on load in either state (pre-paint class + inlined reveal CSS)
- [x] e2e: fresh profile shows no button; visit books; button present on home and summons the overlay

## Testing

- Unit: 144 pass (new: unlock helper; summoner click-summon + ignore-outside; shell unlocks on connect). Typecheck + lint clean (0 errors).
- e2e: 6/6 (new unlock flow; also hardened a pre-upgrade Escape race the new test exposed in the resurrect test).
- Manual (chrome-devtools MCP): verified locked→hidden, books→unlock, home→reveal pre-paint, desktop button visible ≥768px / hidden below, mobile \`>_ console\` in the drawer, both summon on click.