### PR TITLE
feat(terminal): rework overlay into an accessible modal window (#93)

### DIFF
--- a/v2-blog/src/_helpers/terminal/session.ts
+++ b/v2-blog/src/_helpers/terminal/session.ts
@@ -1,80 +1,50 @@
 /**
- * Session-scoped persistence for the terminal overlay: it survives full-page
- * MPA navigations within a tab so the overlay can reopen mid-session with its
- * scrollback and history intact (issue #79). Stored in `sessionStorage` (not
- * local) on purpose — no ghost terminal for visitors returning days later.
+ * Session-scoped persistence of the terminal's command history (issue #93).
  *
- * Deliberately dependency-free: `summon.ts`, a tiny eager script on every page,
- * imports this to decide whether to auto-restore. Pulling in `core.ts` (and
- * thus gsap) here would bloat that critical-path bundle, so the log-line kind
- * is validated as a bare number range mirroring `CommandType`, not imported.
+ * Scope deliberately narrowed from the original continuity store (#79): the
+ * modal terminal no longer auto-reopens after navigation, so the open flag and
+ * the scrollback are gone. Only the command history survives a full-page
+ * navigation, so arrow-up recalls earlier commands when the modal is summoned
+ * again. Stored in `sessionStorage` (per-tab; no ghost terminal for returning
+ * visitors).
+ *
+ * Dependency-free so `summon.ts` and the overlay can both import it without
+ * pulling in heavier terminal code.
  */
 
-/** sessionStorage key holding the serialized session snapshot. */
+/** sessionStorage key holding the serialized history snapshot. */
 export const SESSION_KEY = "book_os:session";
 
-/** Schema version; a snapshot with any other version is discarded on read. */
-export const SESSION_VERSION = 1;
+/**
+ * Schema version. Bumped to 2 when the store was narrowed to history-only;
+ * legacy v1 continuity blobs are ignored on read.
+ */
+export const SESSION_VERSION = 2;
 
-/** Maximum scrollback lines retained; older lines are dropped on append. */
-export const LOG_CAP = 100;
-
-/** Valid `CommandType` ordinals (log, logdata, command, title, error, status). */
-const VALID_KINDS = new Set([0, 1, 2, 3, 4, 5]);
-
-/** One persisted scrollback line: text plus its `CommandType` ordinal. */
-export interface LogLine {
-  t: string;
-  k: number;
-}
-
-/** A full terminal session snapshot persisted across a page navigation. */
-export interface SessionSnapshot {
+/** Persisted command-history snapshot. */
+interface HistorySnapshot {
   v: number;
-  open: boolean;
   history: string[];
-  log: LogLine[];
-}
-
-/** An empty, closed snapshot used as the base for the first write. */
-function emptySnapshot(): SessionSnapshot {
-  return { v: SESSION_VERSION, open: false, history: [], log: [] };
 }
 
 /**
- * Validates an untrusted parsed payload into a snapshot. sessionStorage is
- * user-tamperable, so any shape deviation — wrong version, non-array fields,
- * a non-string line/history entry, or an unknown kind — discards the whole
- * blob (returns null) rather than partially trusting it.
+ * Validates an untrusted parsed payload into a history array. sessionStorage is
+ * user-tamperable (and may hold a legacy #79 blob), so any shape deviation —
+ * wrong version, non-array history, or a non-string entry — yields [].
  *
  * @param raw - The `JSON.parse`d storage payload.
- * @returns A well-formed snapshot, or null when anything is off.
+ * @returns The history entries, or [] when anything is off.
  */
-function validate(raw: unknown): SessionSnapshot | null {
-  if (!raw || typeof raw !== "object") return null;
+function validate(raw: unknown): string[] {
+  if (!raw || typeof raw !== "object") return [];
   const o = raw as Record<string, unknown>;
-
-  if (o.v !== SESSION_VERSION) return null;
-  if (typeof o.open !== "boolean") return null;
-  if (!Array.isArray(o.history) || !Array.isArray(o.log)) return null;
-
-  if (!o.history.every((h) => typeof h === "string")) return null;
-
-  const log: LogLine[] = [];
-  for (const line of o.log) {
-    if (!line || typeof line !== "object") return null;
-    const l = line as Record<string, unknown>;
-    if (typeof l.t !== "string" || typeof l.k !== "number" || !VALID_KINDS.has(l.k)) return null;
-    log.push({ t: l.t, k: l.k });
-  }
-
-  return { v: SESSION_VERSION, open: o.open, history: o.history as string[], log };
+  if (o.v !== SESSION_VERSION) return [];
+  if (!Array.isArray(o.history) || !o.history.every((h) => typeof h === "string")) return [];
+  return o.history as string[];
 }
 
 /**
- * A thin, defensive wrapper over a `Storage` holding the terminal session.
- * Writes are eager (read-modify-write per change) so a navigation at any
- * instant — terminal-driven or a plain link click — already has current state.
+ * A thin, defensive wrapper over a `Storage` holding the command history.
  */
 export class TerminalSession {
   private storage: Storage;
@@ -90,63 +60,40 @@ export class TerminalSession {
   }
 
   /**
-   * Reads and validates the stored snapshot.
+   * Reads the persisted command history.
    *
-   * @returns The snapshot, or null when absent, malformed, or tampered.
+   * @returns The history (oldest first), or [] when absent/malformed/legacy.
    */
-  read(): SessionSnapshot | null {
+  readHistory(): string[] {
     let raw: string | null = null;
     try {
       raw = this.storage.getItem(this.key);
     } catch {
-      return null;
+      return [];
     }
-    if (raw === null) return null;
+    if (raw === null) return [];
 
     try {
       return validate(JSON.parse(raw));
     } catch {
-      return null;
+      return [];
     }
   }
 
-  /** Sets the open flag, preserving history and log. */
-  setOpen(open: boolean): void {
-    const snap = this.read() ?? emptySnapshot();
-    snap.open = open;
-    this.write(snap);
-  }
-
-  /** Replaces the recall history, preserving the open flag and log. */
-  setHistory(history: string[]): void {
-    const snap = this.read() ?? emptySnapshot();
-    snap.history = Array.isArray(history) ? [...history] : [];
-    this.write(snap);
-  }
-
-  /** Appends a scrollback line, dropping the oldest beyond {@link LOG_CAP}. */
-  appendLine(t: string, k: number): void {
-    const snap = this.read() ?? emptySnapshot();
-    snap.log.push({ t, k });
-    if (snap.log.length > LOG_CAP) snap.log = snap.log.slice(-LOG_CAP);
-    this.write(snap);
-  }
-
-  /** Removes the stored session (e.g. on close). */
-  clear(): void {
-    try {
-      this.storage.removeItem(this.key);
-    } catch {
-      // storage unavailable (private mode quota, etc.) — nothing to clear
-    }
-  }
-
-  /** Serializes a snapshot to storage, swallowing quota/availability errors. */
-  private write(snap: SessionSnapshot): void {
+  /**
+   * Persists the command history, replacing any prior snapshot.
+   *
+   * @param history - The command lines, oldest first.
+   */
+  writeHistory(history: string[]): void {
+    const snap: HistorySnapshot = {
+      v: SESSION_VERSION,
+      history: Array.isArray(history) ? [...history] : [],
+    };
     try {
       this.storage.setItem(this.key, JSON.stringify(snap));
     } catch {
-      // storage full or unavailable — continuity is best-effort, never fatal
+      // storage full or unavailable — history recall is best-effort
     }
   }
 }

--- a/v2-blog/src/_helpers/terminal/summon.ts
+++ b/v2-blog/src/_helpers/terminal/summon.ts
@@ -13,8 +13,6 @@ export function matchesSummonCombo(event: KeyboardEvent): boolean {
   return (event.ctrlKey || event.metaKey) && event.shiftKey && event.code === "KeyC";
 }
 
-import { TerminalSession } from "./session.ts";
-
 /** Custom element tag for the lazily-loaded overlay. */
 const OVERLAY_TAG = "terminal-overlay";
 /** Built URL of the overlay bundle, lazy-loaded on first summon. */
@@ -75,16 +73,8 @@ export function createSummoner(target: Window = window): () => void {
   target.addEventListener("keydown", onKeydown, true);
   doc.addEventListener("click", onClick);
 
-  // Session continuity (#79): if the overlay was open when we left the previous
-  // page, re-mount it here. Deferred to idle so it never competes with the
-  // destination page's first contentful paint. The overlay self-opens and
-  // replays its scrollback during restore, so we only mount it (no open attr).
-  if (new TerminalSession().read()?.open) {
-    const schedule = target.requestIdleCallback
-      ? target.requestIdleCallback.bind(target)
-      : (cb: () => void) => target.setTimeout(cb, 50);
-    schedule(() => ensureOverlay());
-  }
+  // The overlay is summoned deliberately only (combo or button) — it never
+  // auto-opens after a navigation (issue #93, superseding #79's auto-reopen).
 
   return () => {
     target.removeEventListener("keydown", onKeydown, true);

--- a/v2-blog/src/components/menu-mobile.ts
+++ b/v2-blog/src/components/menu-mobile.ts
@@ -45,10 +45,17 @@ export class MenuMobile extends LitElement {
 
   private async _handleClickLink(e: MouseEvent) {
     const target = e.target as HTMLElement;
+
+    // A terminal summon trigger closes the drawer; the summoner (a document-
+    // level listener) independently opens the modal on the same click.
+    if (target.closest('[data-terminal-summon]')) {
+      this._handleOpen();
+      return;
+    }
+
     const link = target.closest('a');
     if (!link) return;
 
-    console.log(target, link, link?.target);
     if (e.ctrlKey || e.metaKey || e.shiftKey || e.altKey || e.button !== 0 || link.target === '_blank') {
       this._handleOpen();
       return;

--- a/v2-blog/src/components/terminal-overlay.ts
+++ b/v2-blog/src/components/terminal-overlay.ts
@@ -1,7 +1,6 @@
 import { css, html, LitElement, PropertyValues } from "lit";
 import { customElement, property, query } from "lit/decorators.js";
 import { adoptTailwind } from "../_helpers/styleLoader.ts";
-import { animator } from "../_helpers/animationManager.ts";
 import { CommandType, TerminalCore } from "../_helpers/terminal/core.ts";
 import type { ParsedCommand } from "../_helpers/terminal/parser.ts";
 import {
@@ -16,61 +15,116 @@ import {
 import { TerminalSession } from "../_helpers/terminal/session.ts";
 
 /**
- * Site-wide summonable terminal overlay (the "cheat console").
- * A shadow-DOM drop-down panel built on the shared terminal core. Mounted and
- * toggled by the summoner via the reflected `open` attribute.
+ * Site-wide summonable terminal — an accessible modal window (issue #93).
+ *
+ * A shadow-DOM `<dialog>` opened with `showModal()`: focus is trapped, the
+ * background is inert, Escape and a backdrop click close it, and focus is
+ * restored on close by the platform. Desktop shows a centered terminal window
+ * with chrome; mobile goes fullscreen. Summoned deliberately (combo or button)
+ * — it never auto-opens after a navigation. Only command history persists
+ * across navigations, so arrow-up recalls earlier commands.
  */
 @customElement("terminal-overlay")
 export class TerminalOverlay extends LitElement {
 
   @property({ type: Boolean, reflect: true }) open = false;
 
-  // Critical layout lives here (synchronous) because the overlay mounts already
-  // open on first summon, before the async shadow-Tailwind fetch resolves.
   static styles = css`
     :host { display: contents; }
 
-    /* Rendered in the top layer via the Popover API so it paints above the
-       page regardless of ancestor stacking contexts (body has will-change).
-       These also override the UA popover defaults (centering, border, padding). */
-    #overlay-panel {
+    /* The terminal window. Centered by the UA in the top layer when shown via
+       showModal(); we override the UA dialog defaults (margin/padding/border). */
+    #overlay-dialog {
       position: fixed;
-      inset: 0 0 auto 0;
-      margin: 0;
-      width: auto;
-      max-width: none;
-      height: 45vh;
-      max-height: 45vh;
+      margin: auto;
       padding: 0;
-      border: 0;
-      border-bottom: 1px solid var(--term-border);
-      display: block;
-      transform: translateY(-100%);
+      width: min(720px, 92vw);
+      height: min(70vh, 560px);
+      max-width: 92vw;
+      max-height: 80vh;
+      border: 1px solid var(--term-border);
+      border-radius: 10px;
+      overflow: hidden;
+      background: var(--term-bg);
       color: var(--term-text);
-      box-shadow: 0 12px 40px rgba(0, 0, 0, 0.45);
+      box-shadow: 0 24px 60px rgba(0, 0, 0, 0.5);
       font-family: var(--font-mono, ui-monospace, "IBM Plex Mono", monospace);
     }
 
-    /* A real painted fill rather than a CSS background on the popover element:
-       a top-layer popover only reliably paints its background where there is
-       content, leaving empty areas transparent. This div always paints. */
-    #overlay-bg {
-      position: absolute;
-      inset: 0;
-      z-index: 0;
-      background: var(--term-bg);
+    #overlay-dialog:not([open]) { display: none; }
+    #overlay-dialog[open] { display: flex; flex-direction: column; }
+
+    #overlay-dialog::backdrop {
+      background: rgba(0, 0, 0, 0.55);
     }
 
-    #overlay-inner {
-      position: relative;
-      z-index: 1;
+    @media (prefers-reduced-motion: no-preference) {
+      #overlay-dialog[open] { animation: term-window-in 180ms ease both; }
+      #overlay-dialog[open]::backdrop { animation: term-backdrop-in 180ms ease both; }
+    }
+
+    @keyframes term-window-in {
+      from { opacity: 0; transform: translateY(-8px) scale(0.985); }
+      to { opacity: 1; transform: none; }
+    }
+
+    @keyframes term-backdrop-in {
+      from { opacity: 0; }
+      to { opacity: 1; }
+    }
+
+    /* Title bar: tab label + close. */
+    #overlay-titlebar {
+      flex: none;
       display: flex;
-      flex-direction: column;
-      height: 100%;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0.45rem 0.5rem 0.45rem 0.9rem;
+      border-bottom: 1px solid var(--term-border);
+      background: var(--term-surface);
     }
 
-    @media (max-width: 768px) {
-      #overlay-panel { height: 60vh; max-height: 60vh; }
+    #overlay-tab {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.55ch;
+      font-size: 0.78rem;
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      color: var(--term-muted);
+    }
+
+    #overlay-tab::before {
+      content: "";
+      width: 0.6em;
+      height: 0.6em;
+      border-radius: 50%;
+      background: var(--term-accent);
+    }
+
+    #overlay-close {
+      flex: none;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 2rem;
+      height: 2rem;
+      border: 0;
+      border-radius: 6px;
+      background: transparent;
+      color: var(--term-muted);
+      font: inherit;
+      font-size: 1rem;
+      line-height: 1;
+      cursor: pointer;
+      transition: background 0.15s, color 0.15s;
+    }
+
+    #overlay-close:hover,
+    #overlay-close:focus-visible {
+      background: var(--term-accent);
+      color: var(--term-on-accent);
+      outline: none;
     }
 
     #overlay-log {
@@ -122,6 +176,7 @@ export class TerminalOverlay extends LitElement {
     }
 
     #overlay-form {
+      flex: none;
       display: flex;
       align-items: center;
       gap: 0.5rem;
@@ -135,8 +190,9 @@ export class TerminalOverlay extends LitElement {
       font-weight: 600;
     }
 
-    /* Segmented vim-style status bar. */
+    /* Segmented vim-style status bar (window footer; hidden on mobile). */
     #overlay-status {
+      flex: none;
       display: flex;
       align-items: stretch;
       font-size: 0.72rem;
@@ -176,6 +232,19 @@ export class TerminalOverlay extends LitElement {
       outline: none;
     }
 
+    /* Fullscreen on mobile; drop the footer status bar to save space. */
+    @media (max-width: 768px) {
+      #overlay-dialog {
+        width: 100dvw;
+        height: 100dvh;
+        max-width: none;
+        max-height: none;
+        border: 0;
+        border-radius: 0;
+      }
+      #overlay-status { display: none; }
+    }
+
     .sr-only {
       position: absolute;
       width: 1px;
@@ -189,35 +258,23 @@ export class TerminalOverlay extends LitElement {
     }
   `;
 
-  @query("#overlay-panel") private _panel!: HTMLElement;
+  @query("#overlay-dialog") private _dialog!: HTMLDialogElement;
   @query("#overlay-log") private _log!: HTMLElement;
   @query("#overlay-input") private _input!: HTMLTextAreaElement;
   @query("#overlay-form") private _form!: HTMLFormElement;
 
-  private _restoreFocusTo: Element | null = null;
   private _skipAnimations =
     window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches ?? false;
 
-  /** Session-scoped continuity store (survives full-page navigations). */
+  /** Per-tab command-history store (survives full-page navigations). */
   private _session = new TerminalSession();
-  /** True while replaying restored scrollback, to suppress re-persisting it. */
-  private _restoring = false;
-  /** When set, the next open settles in place instead of sliding (restore). */
-  private _skipSlideOnce = false;
-  /** Resolves once any session restore on mount has finished (test hook). */
-  private _restoreComplete: Promise<void> | null = null;
-
-  /** Awaitable that settles after a mount-time session restore completes. */
-  get restoreComplete(): Promise<void> | null {
-    return this._restoreComplete;
-  }
 
   private _core = new TerminalCore({
     commands: {
       help: async (ctx: ParsedCommand) => {
         await this._core.append(ctx.raw, 0.2, CommandType.command);
         await this._core.append(
-          "help - list commands\nls [folder] - browse the site tree (blog, books, …)\nopen <slug> - go to a page",
+          "help - list commands\nls [folder] - browse the site tree (blog, books, …)\nopen <slug> - go to a page\nexit / q - close the terminal",
           0.3,
           CommandType.logdata
         );
@@ -225,6 +282,9 @@ export class TerminalOverlay extends LitElement {
 
       ls: async (ctx: ParsedCommand) => this._listContent(ctx),
       list: async (ctx: ParsedCommand) => this._listContent(ctx),
+
+      exit: async (ctx: ParsedCommand) => this._exit(ctx),
+      q: async (ctx: ParsedCommand) => this._exit(ctx),
 
       open: async (ctx: ParsedCommand) => {
         await this._core.append(ctx.raw, 0.2, CommandType.command);
@@ -260,12 +320,19 @@ export class TerminalOverlay extends LitElement {
     },
     logEl: () => this._log,
     skipAnimations: () => this._skipAnimations,
-    onLineWritten: (line) => {
-      this._scrollToBottom();
-      // Mirror live output into the session; restore replay is already stored.
-      if (!this._restoring) this._session.appendLine(line.text, line.kind);
-    },
+    onLineWritten: () => this._scrollToBottom(),
   });
+
+  /**
+   * Closes the terminal in response to the `exit` / `q` command.
+   *
+   * @param ctx - The parsed command (echoed before closing).
+   * @returns A promise that settles once the echo is written.
+   */
+  private async _exit(ctx: ParsedCommand): Promise<void> {
+    await this._core.append(ctx.raw, 0.2, CommandType.command);
+    this.open = false;
+  }
 
   /**
    * Handles `ls [target]` against the site tree:
@@ -308,9 +375,9 @@ export class TerminalOverlay extends LitElement {
   }
 
   async firstUpdated() {
-    // Kick off restore synchronously (before the async style load) so the
-    // replay isn't gated on Tailwind and `restoreComplete` is set immediately.
-    this._restoreComplete = this._maybeRestore();
+    // Rehydrate arrow-up history from earlier in the tab (the panel itself
+    // opens fresh — no scrollback is restored, see #93).
+    this._core.history.load(this._session.readHistory());
     try {
       await adoptTailwind(this.renderRoot as ShadowRoot, "terminal-overlay-shadow.css");
     } catch (e) {
@@ -318,138 +385,63 @@ export class TerminalOverlay extends LitElement {
     }
   }
 
-  /**
-   * Restores a continued session on mount: if the stored snapshot was left
-   * open, replays its scrollback instantly, rehydrates history, reopens without
-   * sliding, and prints a `cd ~<path>` arrival line for the new page.
-   *
-   * @returns A promise that settles once restore (if any) has finished.
-   */
-  private async _maybeRestore(): Promise<void> {
-    const snap = this._session.read();
-    if (!snap || !snap.open) return;
-
-    this._restoring = true;
-    for (const line of snap.log) {
-      await this._core.append(line.t, 0, line.k);
-    }
-    this._restoring = false;
-
-    this._core.history.load(snap.history);
-
-    this._skipSlideOnce = true;
-    this.open = true;
-    await this.updateComplete;
-
-    const path = window.location.pathname.replace(/\/+$/, "");
-    await this._core.append(`cd ~${path}`, 0, CommandType.status);
-  }
-
   protected updated(changed: PropertyValues): void {
     if (changed.has("open")) {
       if (this.open) {
-        this._onOpened();
-        this._session.setOpen(true);
-      } else {
-        const wasOpen = changed.get("open") as boolean | undefined;
-        this._onClosed(wasOpen);
-        // Only a real close ends the session; the initial render (wasOpen
-        // undefined) must not wipe a session we're about to restore.
-        if (wasOpen) this._session.clear();
+        this._showModal();
+      } else if (changed.get("open")) {
+        this._closeModal();
       }
     }
   }
 
-  /**
-   * Focuses the input and slides the panel in when the overlay opens.
-   *
-   * @returns `void`.
-   */
-  private _onOpened(): void {
-    this._showPopover();
-    this._restoreFocusTo = document.activeElement;
+  /** Opens the dialog modally and focuses the prompt. */
+  private _showModal(): void {
+    if (typeof this._dialog?.showModal === "function") {
+      try {
+        this._dialog.showModal();
+      } catch {
+        // already open — ensure it is at least shown
+        this._dialog.setAttribute("open", "");
+      }
+    } else {
+      // <dialog>.showModal unsupported (older engines / jsdom): degrade to a
+      // plain open dialog so the terminal is still usable.
+      this._dialog?.setAttribute("open", "");
+    }
     this._input?.focus();
-
-    // A continuity restore appears already-open: settle in place, no slide.
-    if (this._skipSlideOnce) {
-      this._skipSlideOnce = false;
-      if (this._panel) this._panel.style.transform = "translateY(0)";
-      return;
-    }
-
-    void this._slide(true);
   }
 
-  /**
-   * Slides the panel out and restores focus when the overlay closes.
-   *
-   * @param wasOpen - Whether the overlay was previously open (skips work on first render).
-   * @returns `void`.
-   */
-  private _onClosed(wasOpen: boolean | undefined): void {
-    if (!wasOpen) return;
-
-    const restore = this._restoreFocusTo;
-    this._restoreFocusTo = null;
-
-    // Slide out, then leave the top layer; restore focus immediately.
-    void this._slide(false).then(() => this._hidePopover());
-
-    if (restore instanceof HTMLElement) {
-      restore.focus();
-    }
-  }
-
-  /** Promotes the panel into the top layer (no-op where unsupported). */
-  private _showPopover(): void {
+  /** Closes the dialog (the platform restores focus to the opener). */
+  private _closeModal(): void {
     try {
-      (this._panel as unknown as { showPopover?: () => void })?.showPopover?.();
+      this._dialog?.close?.();
     } catch {
-      // already shown or popover unsupported — safe to ignore
-    }
-  }
-
-  /** Removes the panel from the top layer (no-op where unsupported). */
-  private _hidePopover(): void {
-    try {
-      (this._panel as unknown as { hidePopover?: () => void })?.hidePopover?.();
-    } catch {
-      // already hidden or popover unsupported — safe to ignore
+      this._dialog?.removeAttribute("open");
     }
   }
 
   /**
-   * Animates the panel drop-down; reduced motion is handled by the animator.
-   *
-   * @param show - Whether the panel is sliding into view.
-   * @returns `void`.
+   * Syncs `open` when the dialog is dismissed by the platform (Escape) or by
+   * `close()`, so the component state always tracks the dialog.
    */
-  private _slide(show: boolean): Promise<void> {
-    if (!this._panel) return Promise.resolve();
-    animator.cancel(this._panel);
-    const keyframes = show
-      ? [{ transform: "translateY(-100%)" }, { transform: "translateY(0)" }]
-      : [{ transform: "translateY(0)" }, { transform: "translateY(-100%)" }];
-    return animator.animate(this._panel, keyframes, {
-      duration: 320,
-      easing: "cubic-bezier(.37,.79,.14,.93)",
-      fill: "both",
-    });
+  private _onDialogClose(): void {
+    if (this.open) this.open = false;
+  }
+
+  /** Closes the terminal when the dimmed backdrop (outside the window) is clicked. */
+  private _onDialogClick(e: MouseEvent): void {
+    if (e.target === this._dialog) this.open = false;
   }
 
   /**
-   * Handles panel-level keys: Escape closes; Enter (without Shift) submits.
+   * Handles prompt keys: Enter (without Shift) submits; Arrow Up/Down recall
+   * history. Escape is handled natively by the dialog.
    *
-   * @param e - The keydown event from the panel or its input.
+   * @param e - The keydown event from the dialog or its input.
    * @returns `void`.
    */
   private _onKeydown(e: KeyboardEvent): void {
-    if (e.key === "Escape") {
-      e.preventDefault();
-      this.open = false;
-      return;
-    }
-
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       this._form?.requestSubmit();
@@ -475,7 +467,8 @@ export class TerminalOverlay extends LitElement {
   }
 
   /**
-   * Runs the submitted command line through the terminal core.
+   * Runs the submitted command line through the terminal core and persists the
+   * updated history for arrow-up recall after a navigation.
    *
    * @param e - The form submit event.
    * @returns A promise that settles when the command finishes.
@@ -485,7 +478,7 @@ export class TerminalOverlay extends LitElement {
     const raw = this._input?.value ?? "";
     this._input.value = "";
     await this._core.run(raw);
-    this._session.setHistory(this._core.history.snapshot());
+    this._session.writeHistory(this._core.history.snapshot());
   }
 
   /** Keeps the log scrolled to the latest line. */
@@ -495,33 +488,39 @@ export class TerminalOverlay extends LitElement {
 
   protected render(): unknown {
     return html`
-      <section
-        id="overlay-panel"
-        popover="manual"
-        role="dialog"
+      <dialog
+        id="overlay-dialog"
         aria-label="Terminal"
         @keydown=${this._onKeydown}
+        @close=${this._onDialogClose}
+        @click=${this._onDialogClick}
       >
-        <div id="overlay-bg" aria-hidden="true"></div>
-        <div id="overlay-inner">
-          <pre id="overlay-log"></pre>
-          <form id="overlay-form" @submit=${this._onSubmit}>
-            <label class="sr-only" for="overlay-input">Terminal command</label>
-            <textarea
-              id="overlay-input"
-              name="command"
-              rows="1"
-              spellcheck="false"
-              autocomplete="off"
-            ></textarea>
-          </form>
-          <div id="overlay-status" aria-hidden="true">
-            <span class="status-mode">cheat</span>
-            <span class="status-path">~/book_os</span>
-            <span class="status-id">◍ reader</span>
-          </div>
+        <header id="overlay-titlebar">
+          <span id="overlay-tab">book_os</span>
+          <button
+            id="overlay-close"
+            type="button"
+            aria-label="Close terminal"
+            @click=${() => (this.open = false)}
+          >✕</button>
+        </header>
+        <pre id="overlay-log"></pre>
+        <form id="overlay-form" @submit=${this._onSubmit}>
+          <label class="sr-only" for="overlay-input">Terminal command</label>
+          <textarea
+            id="overlay-input"
+            name="command"
+            rows="1"
+            spellcheck="false"
+            autocomplete="off"
+          ></textarea>
+        </form>
+        <div id="overlay-status" aria-hidden="true">
+          <span class="status-mode">cheat</span>
+          <span class="status-path">~/book_os</span>
+          <span class="status-id">◍ reader</span>
         </div>
-      </section>
+      </dialog>
     `;
   }
 }

--- a/v2-blog/tests/e2e/terminal-overlay.spec.ts
+++ b/v2-blog/tests/e2e/terminal-overlay.spec.ts
@@ -55,7 +55,7 @@ test("the overlay is not summonable on the books terminal page", async ({ page }
   await expect(page.locator("terminal-overlay")).toHaveCount(0);
 });
 
-test("session continuity: the overlay reopens with history after open navigates", async ({ page }) => {
+test("after open navigates, the overlay does NOT reopen; history survives for re-summon", async ({ page }) => {
   await page.goto("/");
   await page.keyboard.press("Control+Shift+C");
 
@@ -66,19 +66,45 @@ test("session continuity: the overlay reopens with history after open navigates"
   await page.keyboard.press("Enter");
   await page.waitForURL("**/blog/2025/using-ngrok-to-test-some-web-things/");
 
-  // The overlay re-summons itself on the destination (after paint, on idle).
-  const overlay = page.locator("terminal-overlay");
-  await expect(overlay).toHaveAttribute("open", "", { timeout: 10000 });
+  // It must not auto-open on the destination (no continuity reopen).
+  await page.waitForTimeout(800);
+  await expect(page.locator("terminal-overlay")).toHaveCount(0);
 
-  // Scrollback replayed + a cd-style arrival line for the new path.
-  await expect(page.locator("#overlay-log")).toContainText(
-    "cd ~/blog/2025/using-ngrok-to-test-some-web-things"
-  );
-
-  // Arrow-up recalls the command issued before the jump.
-  await input.focus();
+  // Re-summoning gives a fresh log, but arrow-up still recalls the prior command.
+  await page.keyboard.press("Control+Shift+C");
+  await expect(page.locator("#overlay-input")).toBeFocused();
+  await expect(page.locator("#overlay-log")).toBeEmpty();
   await page.keyboard.press("ArrowUp");
-  await expect(input).toHaveValue("open ngrok");
+  await expect(page.locator("#overlay-input")).toHaveValue("open ngrok");
+});
+
+test("closes via the ✕ button", async ({ page }) => {
+  await page.goto("/");
+  await page.keyboard.press("Control+Shift+C");
+  await expect(page.locator("#overlay-input")).toBeFocused();
+
+  await page.locator("#overlay-close").click();
+  await expect(page.locator("terminal-overlay")).not.toHaveAttribute("open", "");
+});
+
+test("closes via the exit command", async ({ page }) => {
+  await page.goto("/");
+  await page.keyboard.press("Control+Shift+C");
+  await expect(page.locator("#overlay-input")).toBeFocused();
+
+  await page.locator("#overlay-input").fill("exit");
+  await page.keyboard.press("Enter");
+  await expect(page.locator("terminal-overlay")).not.toHaveAttribute("open", "");
+});
+
+test("closes on a backdrop click", async ({ page }) => {
+  await page.goto("/");
+  await page.keyboard.press("Control+Shift+C");
+  await expect(page.locator("#overlay-input")).toBeFocused();
+
+  // Click the dimmed backdrop in the top-left, outside the centered window.
+  await page.mouse.click(5, 5);
+  await expect(page.locator("terminal-overlay")).not.toHaveAttribute("open", "");
 });
 
 test("unlock: visiting the books page reveals the site-wide terminal button", async ({ page }) => {
@@ -102,18 +128,22 @@ test("unlock: visiting the books page reveals the site-wide terminal button", as
   await expect(page.locator("terminal-overlay")).toHaveAttribute("open", "");
 });
 
-test("closing the overlay then navigating normally does not resurrect it", async ({ page }) => {
+test("mobile: summoning from the drawer closes the drawer and opens the modal", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 800 });
+
+  // Unlock so the drawer's >_ console entry is present.
+  await page.goto("/books/");
+  await page.waitForFunction(() => localStorage.getItem("book_os:unlocked") !== null);
   await page.goto("/");
-  await page.keyboard.press("Control+Shift+C");
+
+  // Open the mobile drawer, then tap the summon entry.
+  await page.getByRole("button", { name: "Menu", exact: true }).click();
+  const summon = page.locator("menu-mobile [data-terminal-summon]");
+  await expect(summon).toBeVisible();
+  await summon.click();
+
+  // Drawer closes; the modal opens fullscreen with focus in the input.
+  await expect(page.locator("menu-mobile")).not.toHaveAttribute("isopen", "");
   await expect(page.locator("terminal-overlay")).toHaveAttribute("open", "");
-  // Wait for the lazy bundle to upgrade the element (input focused) before
-  // Escape, otherwise the keydown handler isn't wired yet.
   await expect(page.locator("#overlay-input")).toBeFocused();
-
-  await page.keyboard.press("Escape");
-  await expect(page.locator("terminal-overlay")).not.toHaveAttribute("open", "");
-
-  await page.goto("/about/");
-  // A normal navigation after closing must not bring the overlay back.
-  await expect(page.locator("terminal-overlay")).toHaveCount(0);
 });

--- a/v2-blog/tests/unit/components/menu-mobile.test.ts
+++ b/v2-blog/tests/unit/components/menu-mobile.test.ts
@@ -58,4 +58,28 @@ describe("menu-mobile", () => {
     expect(document.body.style.overflow).toBe("initial");
     expect(animatorMock.animate).toHaveBeenCalledTimes(2);
   });
+
+  it("closes the drawer when a terminal summon trigger is clicked", async () => {
+    const element = new MenuMobile();
+    const summon = document.createElement("button");
+    summon.setAttribute("data-terminal-summon", "");
+    summon.setAttribute("slot", "content");
+    element.appendChild(summon);
+    document.body.appendChild(element);
+    await element.updateComplete;
+
+    // open the drawer
+    element.shadowRoot?.querySelector("button")?.click();
+    await element.updateComplete;
+    await Promise.resolve();
+    expect(element.isOpen).toBe(true);
+
+    // clicking the summon trigger closes it (the summoner opens the modal)
+    summon.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await element.updateComplete;
+    await Promise.resolve();
+
+    expect(element.isOpen).toBe(false);
+    expect(document.body.style.overflow).toBe("initial");
+  });
 });

--- a/v2-blog/tests/unit/components/terminal-overlay.test.ts
+++ b/v2-blog/tests/unit/components/terminal-overlay.test.ts
@@ -1,10 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { animatorMock, gsapMock } = vi.hoisted(() => ({
-  animatorMock: {
-    cancel: vi.fn(),
-    animate: vi.fn(() => Promise.resolve()),
-  },
+const { gsapMock } = vi.hoisted(() => ({
   gsapMock: {
     to: vi.fn((_t, o?: { onUpdate?: () => void; onComplete?: () => void }) => {
       o?.onUpdate?.();
@@ -18,9 +14,6 @@ vi.mock("gsap", () => ({ gsap: gsapMock }));
 vi.mock("../../../src/_helpers/styleLoader.ts", () => ({
   adoptTailwind: () => Promise.resolve(),
 }));
-vi.mock("../../../src/_helpers/animationManager.ts", () => ({
-  animator: animatorMock,
-}));
 
 import { TerminalOverlay } from "../../../src/components/terminal-overlay.ts";
 import { TerminalSession } from "../../../src/_helpers/terminal/session.ts";
@@ -32,46 +25,53 @@ async function mountOverlay() {
   return el;
 }
 
+function $(el: TerminalOverlay, selector: string) {
+  return el.shadowRoot!.querySelector(selector);
+}
+
 function submit(el: TerminalOverlay, value: string) {
   const input = el.shadowRoot!.querySelector<HTMLTextAreaElement>("#overlay-input")!;
   input.value = value;
-  const form = el.shadowRoot!.querySelector<HTMLFormElement>("#overlay-form")!;
-  form.requestSubmit();
+  el.shadowRoot!.querySelector<HTMLFormElement>("#overlay-form")!.requestSubmit();
+}
+
+async function flush() {
+  for (let i = 0; i < 12; i++) await Promise.resolve();
 }
 
 beforeEach(() => {
   document.body.innerHTML = "";
   sessionStorage.clear();
-  animatorMock.cancel.mockClear();
-  animatorMock.animate.mockClear();
 });
 
 describe("terminal-overlay", () => {
-  it("exposes a dialog and moves focus to the input when opened", async () => {
+  it("is a modal dialog and focuses the input when opened", async () => {
     const el = await mountOverlay();
 
     el.open = true;
     await el.updateComplete;
 
-    const dialog = el.shadowRoot!.querySelector('[role="dialog"]');
+    const dialog = $(el, "#overlay-dialog") as HTMLDialogElement;
     expect(dialog).not.toBeNull();
-    expect(el.shadowRoot!.activeElement).toBe(el.shadowRoot!.querySelector("#overlay-input"));
+    expect(dialog.getAttribute("aria-label")).toBe("Terminal");
+    expect(dialog.hasAttribute("open")).toBe(true);
+    expect(el.shadowRoot!.activeElement).toBe($(el, "#overlay-input"));
   });
 
-  it("runs the help command and appends output to the log", async () => {
+  it("runs the help command and lists the close commands", async () => {
     const el = await mountOverlay();
     el.open = true;
     await el.updateComplete;
 
     submit(el, "help");
-    await el.updateComplete;
-    await Promise.resolve();
+    await flush();
 
-    const log = el.shadowRoot!.querySelector("#overlay-log")!;
+    const log = $(el, "#overlay-log")!;
     expect(log.textContent).toContain("help - list commands");
+    expect(log.textContent).toContain("exit / q - close the terminal");
   });
 
-  it("submits the command when Enter is pressed in the input", async () => {
+  it("submits on Enter and inserts a newline on Shift+Enter", async () => {
     const el = await mountOverlay();
     el.open = true;
     await el.updateComplete;
@@ -79,189 +79,127 @@ describe("terminal-overlay", () => {
     const input = el.shadowRoot!.querySelector<HTMLTextAreaElement>("#overlay-input")!;
     input.value = "help";
     input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
-    await el.updateComplete;
-    await Promise.resolve();
-
-    expect(el.shadowRoot!.querySelector("#overlay-log")!.textContent).toContain("help - list commands");
+    await flush();
+    expect($(el, "#overlay-log")!.textContent).toContain("help - list commands");
     expect(input.value).toBe("");
+
+    const shiftEnter = new KeyboardEvent("keydown", { key: "Enter", shiftKey: true, bubbles: true, cancelable: true });
+    input.dispatchEvent(shiftEnter);
+    expect(shiftEnter.defaultPrevented).toBe(false);
   });
 
-  it("inserts a newline (does not submit) on Shift+Enter", async () => {
-    const el = await mountOverlay();
-    el.open = true;
-    await el.updateComplete;
-
-    const input = el.shadowRoot!.querySelector<HTMLTextAreaElement>("#overlay-input")!;
-    input.value = "hel";
-    const event = new KeyboardEvent("keydown", { key: "Enter", shiftKey: true, bubbles: true, cancelable: true });
-    input.dispatchEvent(event);
-
-    expect(event.defaultPrevented).toBe(false);
-  });
-
-  it("closes when Escape is pressed", async () => {
-    const el = await mountOverlay();
-    el.open = true;
-    await el.updateComplete;
-
-    const panel = el.shadowRoot!.querySelector("#overlay-panel")!;
-    panel.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
-    await el.updateComplete;
-
-    expect(el.open).toBe(false);
-  });
-
-  it("restores focus to the previously focused element on close", async () => {
-    const trigger = document.createElement("button");
-    document.body.appendChild(trigger);
-    trigger.focus();
-
-    const el = await mountOverlay();
-    el.open = true;
-    await el.updateComplete;
-    el.open = false;
-    await el.updateComplete;
-
-    expect(document.activeElement).toBe(trigger);
-  });
-
-  it("slides the panel in via the animator on open", async () => {
-    const el = await mountOverlay();
-    el.open = true;
-    await el.updateComplete;
-
-    expect(animatorMock.animate).toHaveBeenCalledTimes(1);
-  });
-
-  describe("history recall", () => {
-    async function pressArrow(el: TerminalOverlay, key: "ArrowUp" | "ArrowDown") {
-      const input = el.shadowRoot!.querySelector<HTMLTextAreaElement>("#overlay-input")!;
-      const event = new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true });
-      input.dispatchEvent(event);
-      await el.updateComplete;
-      return event;
-    }
-
-    it("recalls the previous command into the input on ArrowUp and prevents the default", async () => {
+  describe("closing", () => {
+    it("closes when the ✕ button is clicked", async () => {
       const el = await mountOverlay();
       el.open = true;
       await el.updateComplete;
 
-      submit(el, "help");
+      ($(el, "#overlay-close") as HTMLButtonElement).click();
       await el.updateComplete;
-      await Promise.resolve();
-
-      const event = await pressArrow(el, "ArrowUp");
-
-      const input = el.shadowRoot!.querySelector<HTMLTextAreaElement>("#overlay-input")!;
-      expect(input.value).toBe("help");
-      expect(event.defaultPrevented).toBe(true);
-    });
-
-    it("steps back through several commands and forward again with ArrowDown", async () => {
-      const el = await mountOverlay();
-      el.open = true;
-      await el.updateComplete;
-
-      submit(el, "help");
-      await el.updateComplete;
-      await Promise.resolve();
-      submit(el, "ls");
-      await el.updateComplete;
-      await Promise.resolve();
-
-      const input = el.shadowRoot!.querySelector<HTMLTextAreaElement>("#overlay-input")!;
-
-      await pressArrow(el, "ArrowUp");
-      expect(input.value).toBe("ls");
-      await pressArrow(el, "ArrowUp");
-      expect(input.value).toBe("help");
-
-      await pressArrow(el, "ArrowDown");
-      expect(input.value).toBe("ls");
-      await pressArrow(el, "ArrowDown");
-      expect(input.value).toBe("");
-    });
-  });
-
-  describe("session continuity", () => {
-    it("persists the open flag while open and clears the session on close", async () => {
-      const el = await mountOverlay();
-
-      el.open = true;
-      await el.updateComplete;
-      expect(new TerminalSession().read()?.open).toBe(true);
-
-      el.open = false;
-      await el.updateComplete;
-      expect(new TerminalSession().read()).toBeNull();
-    });
-
-    it("does not clear the session on the initial (never-opened) render", async () => {
-      new TerminalSession().setOpen(true);
-
-      await mountOverlay(); // open defaults to false; must not wipe an existing session
-
-      // a restore will have re-asserted open:true; the key must still exist
-      expect(new TerminalSession().read()).not.toBeNull();
-    });
-
-    it("mirrors written log lines and command history into the session", async () => {
-      const el = await mountOverlay();
-      el.open = true;
-      await el.updateComplete;
-
-      submit(el, "help");
-      // help appends several lines sequentially; persistence (onLineWritten)
-      // trails the synchronous DOM write by a microtask per line — drain them.
-      for (let i = 0; i < 12; i++) await Promise.resolve();
-
-      const snap = new TerminalSession().read()!;
-      expect(snap.log.some((l) => l.t.includes("help - list commands"))).toBe(true);
-      expect(snap.history).toContain("help");
-    });
-
-    it("restores scrollback, history and an arrival line, opening without a slide", async () => {
-      const seed = new TerminalSession();
-      seed.setOpen(true);
-      seed.appendLine("$ ls", 2);
-      seed.appendLine("blog/   3", 0);
-      seed.setHistory(["ls"]);
-
-      const el = new TerminalOverlay();
-      document.body.appendChild(el);
-      await el.updateComplete;
-      await el.restoreComplete;
-      await el.updateComplete;
-
-      // reopened
-      expect(el.open).toBe(true);
-      // scrollback replayed
-      const log = el.shadowRoot!.querySelector("#overlay-log")!;
-      expect(log.textContent).toContain("blog/   3");
-      // arrival line (status-kind cd ~<path>)
-      expect(log.textContent).toContain("cd ~");
-      // history rehydrated → ArrowUp recalls the pre-jump command
-      const input = el.shadowRoot!.querySelector<HTMLTextAreaElement>("#overlay-input")!;
-      input.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowUp", bubbles: true }));
-      await el.updateComplete;
-      expect(input.value).toBe("ls");
-      // opened instantly: no slide animation on a restore
-      expect(animatorMock.animate).not.toHaveBeenCalled();
-    });
-
-    it("does not restore when the stored session is closed", async () => {
-      const seed = new TerminalSession();
-      seed.setOpen(false);
-      seed.appendLine("stale", 0);
-
-      const el = new TerminalOverlay();
-      document.body.appendChild(el);
-      await el.updateComplete;
-      await el.restoreComplete;
 
       expect(el.open).toBe(false);
-      expect(el.shadowRoot!.querySelector("#overlay-log")!.textContent).toBe("");
+    });
+
+    it("closes via the exit and q commands", async () => {
+      const el = await mountOverlay();
+
+      el.open = true;
+      await el.updateComplete;
+      submit(el, "exit");
+      await flush();
+      expect(el.open).toBe(false);
+
+      el.open = true;
+      await el.updateComplete;
+      submit(el, "q");
+      await flush();
+      expect(el.open).toBe(false);
+    });
+
+    it("closes on a backdrop click (target is the dialog itself)", async () => {
+      const el = await mountOverlay();
+      el.open = true;
+      await el.updateComplete;
+
+      const dialog = $(el, "#overlay-dialog")!;
+      dialog.dispatchEvent(new MouseEvent("click", { bubbles: true })); // target === dialog
+      await el.updateComplete;
+
+      expect(el.open).toBe(false);
+    });
+
+    it("does not close when inner content is clicked", async () => {
+      const el = await mountOverlay();
+      el.open = true;
+      await el.updateComplete;
+
+      $(el, "#overlay-log")!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await el.updateComplete;
+
+      expect(el.open).toBe(true);
+    });
+
+    it("syncs open=false when the dialog emits a native close (Escape)", async () => {
+      const el = await mountOverlay();
+      el.open = true;
+      await el.updateComplete;
+
+      $(el, "#overlay-dialog")!.dispatchEvent(new Event("close"));
+      await el.updateComplete;
+
+      expect(el.open).toBe(false);
+    });
+  });
+
+  describe("command history (persists across navigations, not scrollback)", () => {
+    it("recalls prior commands with ArrowUp/ArrowDown", async () => {
+      const el = await mountOverlay();
+      el.open = true;
+      await el.updateComplete;
+
+      submit(el, "help");
+      await flush();
+      submit(el, "ls");
+      await flush();
+
+      const input = el.shadowRoot!.querySelector<HTMLTextAreaElement>("#overlay-input")!;
+      const arrow = (key: string) =>
+        input.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
+
+      arrow("ArrowUp");
+      expect(input.value).toBe("ls");
+      arrow("ArrowUp");
+      expect(input.value).toBe("help");
+      arrow("ArrowDown");
+      expect(input.value).toBe("ls");
+    });
+
+    it("persists history to the session on submit", async () => {
+      const el = await mountOverlay();
+      el.open = true;
+      await el.updateComplete;
+
+      submit(el, "help");
+      await flush();
+
+      expect(new TerminalSession().readHistory()).toContain("help");
+    });
+
+    it("rehydrates history from the session on mount, but starts with an empty log", async () => {
+      // Simulate a prior page in the same tab having run a command.
+      new TerminalSession().writeHistory(["open ring"]);
+
+      const el = await mountOverlay();
+      el.open = true;
+      await el.updateComplete;
+
+      // Fresh panel: no scrollback restored.
+      expect($(el, "#overlay-log")!.textContent).toBe("");
+
+      // ... but arrow-up recalls the earlier command.
+      const input = el.shadowRoot!.querySelector<HTMLTextAreaElement>("#overlay-input")!;
+      input.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowUp", bubbles: true }));
+      expect(input.value).toBe("open ring");
     });
   });
 });

--- a/v2-blog/tests/unit/helpers/terminal/session.test.ts
+++ b/v2-blog/tests/unit/helpers/terminal/session.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
-import { LOG_CAP, SESSION_KEY, SESSION_VERSION, TerminalSession } from "../../../../src/_helpers/terminal/session.ts";
+import { SESSION_KEY, SESSION_VERSION, TerminalSession } from "../../../../src/_helpers/terminal/session.ts";
 
 /** Minimal in-memory Storage stand-in (decoupled from jsdom globals). */
 function fakeStorage(): Storage {
@@ -25,75 +25,47 @@ beforeEach(() => {
   session = new TerminalSession(storage);
 });
 
-describe("TerminalSession", () => {
-  it("reads null when nothing has been stored", () => {
-    expect(session.read()).toBeNull();
+describe("TerminalSession (command-history persistence)", () => {
+  it("reads an empty history when nothing is stored", () => {
+    expect(session.readHistory()).toEqual([]);
   });
 
-  it("persists the open flag, history and log lines, then reads them back", () => {
-    session.setOpen(true);
-    session.appendLine("$ ls", 2);
-    session.appendLine("blog/", 0);
-    session.setHistory(["ls"]);
-
-    expect(session.read()).toEqual({
-      v: SESSION_VERSION,
-      open: true,
-      history: ["ls"],
-      log: [
-        { t: "$ ls", k: 2 },
-        { t: "blog/", k: 0 },
-      ],
-    });
+  it("persists a command history and reads it back", () => {
+    session.writeHistory(["ls", "open ring"]);
+    expect(session.readHistory()).toEqual(["ls", "open ring"]);
   });
 
-  it("caps the log to the most recent LOG_CAP lines", () => {
-    for (let i = 0; i < LOG_CAP + 25; i++) session.appendLine(`line ${i}`, 0);
-
-    const snap = session.read()!;
-    expect(snap.log).toHaveLength(LOG_CAP);
-    expect(snap.log[0].t).toBe(`line 25`); // oldest 25 dropped
-    expect(snap.log[snap.log.length - 1].t).toBe(`line ${LOG_CAP + 24}`);
+  it("overwrites the prior history on each write", () => {
+    session.writeHistory(["one"]);
+    session.writeHistory(["two", "three"]);
+    expect(session.readHistory()).toEqual(["two", "three"]);
   });
 
-  it("clear() removes the stored session", () => {
-    session.setOpen(true);
-    session.clear();
-    expect(session.read()).toBeNull();
-    expect(storage.getItem(SESSION_KEY)).toBeNull();
+  it("stores under the documented key and version", () => {
+    session.writeHistory(["ls"]);
+    const raw = JSON.parse(storage.getItem(SESSION_KEY)!);
+    expect(raw.v).toBe(SESSION_VERSION);
+    expect(raw.history).toEqual(["ls"]);
   });
 
-  describe("defensive read (tampered / malformed storage)", () => {
-    const reject = (raw: string) => {
+  describe("defensive read (tampered / malformed / legacy storage)", () => {
+    const expectEmpty = (raw: string) => {
       storage.setItem(SESSION_KEY, raw);
-      expect(session.read()).toBeNull();
+      expect(session.readHistory()).toEqual([]);
     };
 
-    it("returns null and never throws on invalid JSON", () => {
-      reject("{not json");
+    it("returns [] and never throws on invalid JSON", () => {
+      expectEmpty("{not json");
     });
 
-    it("rejects a wrong or missing version", () => {
-      reject(JSON.stringify({ v: 999, open: true, history: [], log: [] }));
-      reject(JSON.stringify({ open: true, history: [], log: [] }));
+    it("ignores a wrong or missing version (e.g. a legacy #79 blob)", () => {
+      expectEmpty(JSON.stringify({ v: 1, open: true, history: ["ls"], log: [] }));
+      expectEmpty(JSON.stringify({ history: ["ls"] }));
     });
 
-    it("rejects a non-boolean open flag", () => {
-      reject(JSON.stringify({ v: SESSION_VERSION, open: "yes", history: [], log: [] }));
-    });
-
-    it("rejects a non-array history or log", () => {
-      reject(JSON.stringify({ v: SESSION_VERSION, open: true, history: "ls", log: [] }));
-      reject(JSON.stringify({ v: SESSION_VERSION, open: true, history: [], log: {} }));
-    });
-
-    it("rejects a log line with a non-string text or an unknown kind", () => {
-      reject(JSON.stringify({ v: SESSION_VERSION, open: true, history: [], log: [{ t: 5, k: 0 }] }));
-      reject(JSON.stringify({ v: SESSION_VERSION, open: true, history: [], log: [{ t: "x", k: 99 }] }));
-    });
-
-    it("rejects a history entry that is not a string", () => {
-      reject(JSON.stringify({ v: SESSION_VERSION, open: true, history: [1, 2], log: [] }));
+    it("ignores a non-array history or non-string entries", () => {
+      expectEmpty(JSON.stringify({ v: SESSION_VERSION, history: "ls" }));
+      expectEmpty(JSON.stringify({ v: SESSION_VERSION, history: [1, 2] }));
     });
   });
 });

--- a/v2-blog/tests/unit/helpers/terminal/summoner.test.ts
+++ b/v2-blog/tests/unit/helpers/terminal/summoner.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createSummoner } from "../../../../src/_helpers/terminal/summon.ts";
-import { TerminalSession } from "../../../../src/_helpers/terminal/session.ts";
 
 let dispose: (() => void) | undefined;
 
@@ -23,18 +22,11 @@ beforeEach(() => {
   document.body.innerHTML = "";
   document.head.querySelectorAll("script").forEach((s) => s.remove());
   sessionStorage.clear();
-  // Run idle callbacks synchronously so auto-restore is observable in tests.
-  (window as unknown as { requestIdleCallback: (cb: () => void) => number }).requestIdleCallback =
-    (cb: () => void) => {
-      cb();
-      return 0;
-    };
 });
 
 afterEach(() => {
   dispose?.();
   dispose = undefined;
-  delete (window as unknown as { requestIdleCallback?: unknown }).requestIdleCallback;
 });
 
 describe("createSummoner", () => {
@@ -113,35 +105,14 @@ describe("createSummoner", () => {
     });
   });
 
-  describe("session restore", () => {
-    it("auto-mounts the overlay (and its bundle) on idle when a session was left open", () => {
-      new TerminalSession().setOpen(true);
-
+  describe("no auto-open on navigation (#93)", () => {
+    it("never mounts the overlay on its own — only a combo or click summons it", () => {
       dispose = createSummoner(window);
 
-      // mounted without any keypress; the overlay self-opens during restore,
-      // so the summoner must NOT force the open attribute itself.
-      const overlay = document.querySelector("terminal-overlay");
-      expect(overlay).not.toBeNull();
-      expect(overlay?.hasAttribute("open")).toBe(false);
-      expect(document.head.querySelector('script[src="/components/terminal-overlay.js"]')).not.toBeNull();
-    });
-
-    it("does not auto-mount when there is no session", () => {
-      dispose = createSummoner(window);
-
+      // Just installing the summoner (as every page load does) must not mount
+      // or even fetch the overlay bundle.
       expect(document.querySelector("terminal-overlay")).toBeNull();
       expect(document.head.querySelector('script[src="/components/terminal-overlay.js"]')).toBeNull();
-    });
-
-    it("does not auto-mount when the stored session is closed", () => {
-      const s = new TerminalSession();
-      s.setOpen(true);
-      s.setOpen(false);
-
-      dispose = createSummoner(window);
-
-      expect(document.querySelector("terminal-overlay")).toBeNull();
     });
   });
 });


### PR DESCRIPTION
Closes #93

## What

Reframes the summonable terminal from a Quake-style top drop-down into a deliberate, accessible **modal window**, and removes the auto-reopen-on-navigation behavior (superseding #79's continuity). Driven by two gaps: touch users had no way to close it (Escape-only, `popover=\"manual\"` blocks light-dismiss), and an overlay that auto-reopens after every navigation is disorienting for keyboard/screen-reader users.

## How

- **Native `<dialog>` + `showModal()`** (replaces `popover=\"manual\"`): focus trapped inside, background inert, real `::backdrop`, native Escape, platform focus-restore. Removed the old popover + painted-background workaround.
- **Desktop:** a centered terminal window with chrome — title bar (`book_os` tab + ✕), log, prompt, and the `CHEAT | ~/book_os | reader` status bar as the window footer.
- **Mobile:** fullscreen (`100dvw × 100dvh`), large tappable ✕, prompt pinned to the bottom via `dvh` (above the keyboard), status footer hidden.
- **Close paths:** ✕ button, Escape, backdrop click (desktop), and `exit` / `q` commands (shown in `help`).
- **No open-on-navigate:** `summon.ts` drops the idle auto-mount; the overlay is summoned only by the combo or a button. The session store is slimmed to **history-only** (`readHistory` / `writeHistory`, schema version bumped to 2 so legacy #79 blobs are ignored). The panel opens fresh, but arrow-up still recalls commands from earlier in the tab.
- **Mobile drawer:** `menu-mobile._handleClickLink` now closes the drawer on a `[data-terminal-summon]` click; the summoner independently opens the modal.

## Acceptance criteria (#93)

- [x] Desktop: centered window with title bar, ✕, footer status bar, dimmed backdrop
- [x] Mobile: fullscreen, large ✕, prompt above the keyboard, no status footer
- [x] Native `<dialog>` `showModal()`: focus trapped, background inert, focus restored on close
- [x] Closeable via ✕, Escape, backdrop click, and `exit`/`q`
- [x] Overlay does NOT auto-open after navigation
- [x] Arrow-up still recalls commands from earlier in the tab (history persists; scrollback does not)
- [x] Clicking the summon entry in the mobile drawer closes the drawer and opens the modal
- [x] Combo + header/mobile button still summon; works with the #80 unlock
- [x] Unit + e2e updated (the #79 \"reopens after navigate\" cases became \"does not reopen; history on re-summon\")

## Testing

- Unit: 137 pass (rewrote session/overlay/summoner suites; added the menu-mobile drawer-close test). Typecheck + lint clean (0 errors).
- e2e: 9/9 (summon/help/Escape, ls+open navigates, no-reopen + history survives, ✕/exit/backdrop close, unlock, mobile drawer → fullscreen).
- Manual (chrome-devtools MCP): verified the centered desktop window and the mobile fullscreen layout (screenshots).

## Supersedes

- #79's auto-reopen continuity and #77's drop-down form factor.