### PR TITLE
feat(terminal): delight package + whoami/chime fixes + structured log output (#81)

### DIFF
--- a/v2-blog/src/_helpers/identity.ts
+++ b/v2-blog/src/_helpers/identity.ts
@@ -1,0 +1,45 @@
+/**
+ * Shared fake-identity state (issue #81 follow-up). The single source of truth
+ * for "who the visitor is" in the terminal universe, wrapping the lower-level
+ * {@link IdentityManager}. Used by the home-page `user-fakeid` (which lets you
+ * reroll + set a name) and the terminal `whoami` command, so the chosen
+ * identity never goes stale across surfaces. Mirrors the shared theme helper.
+ */
+
+import { IdentityManager, IDMode } from "./identityManager.ts";
+
+/** Window event dispatched whenever the chosen identity changes (`{ identity }`). */
+export const IDENTITY_CHANGE_EVENT = "identity-change";
+
+/**
+ * The current identity: the user's chosen name if they've set one, otherwise a
+ * deterministic generated default. Read fresh each call, so consumers (e.g.
+ * `whoami`) always reflect the latest choice.
+ *
+ * @returns The identity string in `prefix_suffix::id` form.
+ */
+export function getIdentity(): string {
+  const mgr = IdentityManager.getInstance();
+  return mgr.getCachedName() ?? mgr.getFullIdentity(IDMode.default);
+}
+
+/**
+ * Persists a chosen identity and notifies other surfaces via
+ * {@link IDENTITY_CHANGE_EVENT}.
+ *
+ * @param identity - The identity string to adopt.
+ */
+export function setIdentity(identity: string): void {
+  IdentityManager.getInstance().cacheName(identity);
+  window.dispatchEvent(new CustomEvent(IDENTITY_CHANGE_EVENT, { detail: { identity } }));
+}
+
+/**
+ * Generates a fresh random identity (not yet persisted) — used by the reroll UI
+ * to preview a candidate before the user commits it via {@link setIdentity}.
+ *
+ * @returns A new random identity string.
+ */
+export function nextRandomIdentity(): string {
+  return IdentityManager.getInstance().getFullIdentity(IDMode.random);
+}

--- a/v2-blog/src/_helpers/terminal/blocks.ts
+++ b/v2-blog/src/_helpers/terminal/blocks.ts
@@ -1,0 +1,50 @@
+/**
+ * Structured terminal output (issue: richer log control). A small descriptor
+ * model the core renders to DOM, so commands can emit columns, sections, and
+ * tone-coloured cells instead of only flat text. Kept dependency-free (no gsap)
+ * so data-layer modules like `site-index.ts` can build blocks without pulling
+ * in the rendering engine.
+ */
+
+import type { CommandType } from "./core.ts";
+
+/**
+ * Semantic colour roles mapped to the `--term-*` theme tokens (so output stays
+ * themeable across pinky/dark and free of hard-coded colours).
+ */
+export type Tone = "default" | "muted" | "accent" | "ok" | "err" | "surface" | "warn";
+
+/** One cell in a columns block. */
+export interface Cell {
+  text: string;
+  tone?: Tone;
+  /** Horizontal placement within its grid column (default: start). */
+  align?: "start" | "end";
+}
+
+/**
+ * A renderable unit. `text` is the familiar flat line; `columns` is a grid with
+ * aligned cells; `section` groups a titled, optionally tinted body (one level of
+ * nesting — enough for "a section containing a columns listing").
+ */
+export type Block =
+  | { type: "text"; text: string; kind?: CommandType }
+  | { type: "columns"; rows: Cell[][] }
+  | { type: "section"; title?: string; tone?: Tone; body: Block[] };
+
+/**
+ * Flattens a block to its plain text (for scroll bookkeeping / accessibility).
+ *
+ * @param block - The block to flatten.
+ * @returns The concatenated text content.
+ */
+export function flattenBlock(block: Block): string {
+  switch (block.type) {
+    case "text":
+      return block.text;
+    case "columns":
+      return block.rows.map((row) => row.map((c) => c.text).join(" ")).join("\n");
+    case "section":
+      return [block.title ?? "", ...block.body.map(flattenBlock)].filter(Boolean).join("\n");
+  }
+}

--- a/v2-blog/src/_helpers/terminal/chime.ts
+++ b/v2-blog/src/_helpers/terminal/chime.ts
@@ -1,11 +1,14 @@
 /**
- * The first-ever-summon chime (issue #81): a short, synthesized ascending
- * arpeggio that plays exactly once per browser profile, evoking a 2000s game
+ * The summon chime (issue #81): a short, synthesized ascending arpeggio that
+ * plays once per browser session on the first summon, evoking a 2000s game
  * console without sampling any audio. No asset, no network request — built at
  * runtime with the Web Audio API. Skipped under `prefers-reduced-motion`.
+ *
+ * Per-session (sessionStorage), not once-ever: a returning visitor gets the
+ * little reward again on their next visit, but it stays quiet within a session.
  */
 
-/** localStorage flag marking that the once-ever chime has played. */
+/** sessionStorage flag marking that the chime has played this session. */
 export const CHIME_KEY = "book_os:chimed";
 
 /** Ascending major triad: C5 → E5 → G5 (Hz). */
@@ -34,15 +37,15 @@ function defaultAudioContext(): AudioContext | null {
 }
 
 /**
- * Plays the celebratory chime if this is the first summon ever and motion is
- * allowed. Marks the persistent flag only on a real play, so a reduced-motion
- * or Web-Audio-less visit doesn't burn the once-ever moment.
+ * Plays the celebratory chime if this is the first summon of the session and
+ * motion is allowed. Marks the session flag only on a real play, so a
+ * reduced-motion or Web-Audio-less visit doesn't burn the moment.
  *
  * @param deps - Injectable storage / motion / audio factory (for testing).
  * @returns `true` if the chime actually played.
  */
 export function playFirstSummonChime(deps: ChimeDeps = {}): boolean {
-  const storage = deps.storage ?? localStorage;
+  const storage = deps.storage ?? sessionStorage;
   const prefersReducedMotion = deps.prefersReducedMotion ?? defaultReducedMotion;
 
   if (prefersReducedMotion()) return false;
@@ -56,7 +59,7 @@ export function playFirstSummonChime(deps: ChimeDeps = {}): boolean {
   return true;
 }
 
-/** Whether the chime has already played on this profile. */
+/** Whether the chime has already played this session. */
 function hasChimed(storage: Storage): boolean {
   try {
     return storage.getItem(CHIME_KEY) !== null;

--- a/v2-blog/src/_helpers/terminal/chime.ts
+++ b/v2-blog/src/_helpers/terminal/chime.ts
@@ -1,0 +1,104 @@
+/**
+ * The first-ever-summon chime (issue #81): a short, synthesized ascending
+ * arpeggio that plays exactly once per browser profile, evoking a 2000s game
+ * console without sampling any audio. No asset, no network request — built at
+ * runtime with the Web Audio API. Skipped under `prefers-reduced-motion`.
+ */
+
+/** localStorage flag marking that the once-ever chime has played. */
+export const CHIME_KEY = "book_os:chimed";
+
+/** Ascending major triad: C5 → E5 → G5 (Hz). */
+const NOTES = [523.25, 659.25, 783.99];
+/** Seconds between note onsets. */
+const STEP = 0.12;
+/** Peak gain — deliberately gentle (a blip, not a startle). */
+const PEAK = 0.15;
+
+interface ChimeDeps {
+  storage?: Storage;
+  prefersReducedMotion?: () => boolean;
+  createAudioContext?: () => AudioContext | null;
+}
+
+/** Whether the user prefers reduced motion (defaults to the media query). */
+function defaultReducedMotion(): boolean {
+  return window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches ?? false;
+}
+
+/** Creates an AudioContext, or null where Web Audio is unavailable. */
+function defaultAudioContext(): AudioContext | null {
+  const Ctor =
+    window.AudioContext ?? (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+  return Ctor ? new Ctor() : null;
+}
+
+/**
+ * Plays the celebratory chime if this is the first summon ever and motion is
+ * allowed. Marks the persistent flag only on a real play, so a reduced-motion
+ * or Web-Audio-less visit doesn't burn the once-ever moment.
+ *
+ * @param deps - Injectable storage / motion / audio factory (for testing).
+ * @returns `true` if the chime actually played.
+ */
+export function playFirstSummonChime(deps: ChimeDeps = {}): boolean {
+  const storage = deps.storage ?? localStorage;
+  const prefersReducedMotion = deps.prefersReducedMotion ?? defaultReducedMotion;
+
+  if (prefersReducedMotion()) return false;
+  if (hasChimed(storage)) return false;
+
+  const ctx = (deps.createAudioContext ?? defaultAudioContext)();
+  if (!ctx) return false;
+
+  synthesize(ctx);
+  markChimed(storage);
+  return true;
+}
+
+/** Whether the chime has already played on this profile. */
+function hasChimed(storage: Storage): boolean {
+  try {
+    return storage.getItem(CHIME_KEY) !== null;
+  } catch {
+    return false;
+  }
+}
+
+/** Records that the chime has played. */
+function markChimed(storage: Storage): void {
+  try {
+    storage.setItem(CHIME_KEY, "1");
+  } catch {
+    // storage unavailable — worst case the chime can play again; harmless
+  }
+}
+
+/**
+ * Schedules the three-note arpeggio: a triangle oscillator per note through a
+ * gain envelope (fast attack, exponential release) so it reads as a warm blip.
+ *
+ * @param ctx - The audio context to play into.
+ */
+function synthesize(ctx: AudioContext): void {
+  if (ctx.state === "suspended") void ctx.resume?.();
+  const t0 = ctx.currentTime;
+
+  NOTES.forEach((freq, i) => {
+    const start = t0 + i * STEP;
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+
+    osc.type = "triangle";
+    osc.frequency.setValueAtTime(freq, start);
+
+    gain.gain.setValueAtTime(0.0001, start);
+    gain.gain.linearRampToValueAtTime(PEAK, start + 0.02);
+    gain.gain.exponentialRampToValueAtTime(0.0001, start + 0.22);
+
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+    osc.start(start);
+    osc.stop(start + 0.24);
+  });
+}

--- a/v2-blog/src/_helpers/terminal/core.ts
+++ b/v2-blog/src/_helpers/terminal/core.ts
@@ -2,6 +2,7 @@ import { gsap } from "gsap";
 
 import { parseCommand, ParsedCommand } from "./parser.ts";
 import { CommandHistory } from "./history.ts";
+import { type Block, type Cell, flattenBlock } from "./blocks.ts";
 
 /**
  * Visual kinds for terminal log lines; the name doubles as the CSS class.
@@ -153,5 +154,86 @@ export class TerminalCore {
 
       this.opts.onLineWritten?.({ text: line, kind });
     }
+  }
+
+  /**
+   * Renders a structured block (text / columns / section) to the log. Unlike
+   * {@link append}, structured output appears instantly (no per-char typing),
+   * which suits grids and grouped layouts.
+   *
+   * @param block - The block descriptor to render.
+   * @returns A promise that settles once the block is in the DOM.
+   */
+  async render(block: Block): Promise<void> {
+    const log = this.opts.logEl();
+    if (!log) return;
+
+    log.appendChild(this.buildBlock(block));
+    this.opts.onLineWritten?.({ text: flattenBlock(block), kind: CommandType.log });
+  }
+
+  /**
+   * Builds the DOM for a block (recursing into section bodies).
+   *
+   * @param block - The block descriptor.
+   * @returns The rendered element.
+   */
+  private buildBlock(block: Block): HTMLElement {
+    switch (block.type) {
+      case "text":
+        return this.buildText(block.text, block.kind ?? CommandType.log);
+      case "columns":
+        return this.buildColumns(block.rows);
+      case "section":
+        return this.buildSection(block);
+    }
+  }
+
+  /** Builds a flat text line (same shape as {@link append}, rendered instantly). */
+  private buildText(text: string, kind: CommandType): HTMLElement {
+    const p = document.createElement("p");
+    p.className = `terminal-msg ${CommandType[kind]}`;
+    const badge = commandBadge(kind);
+    if (badge) p.dataset.badge = badge;
+    p.textContent = text;
+    return p;
+  }
+
+  /** Builds a grid of tone/aligned cells; short rows are padded so columns line up. */
+  private buildColumns(rows: Cell[][]): HTMLElement {
+    const cols = rows.reduce((max, row) => Math.max(max, row.length), 0);
+    const grid = document.createElement("div");
+    grid.className = "terminal-cols";
+    grid.style.gridTemplateColumns = `repeat(${cols}, max-content)`;
+
+    for (const row of rows) {
+      for (let i = 0; i < cols; i++) {
+        const cell = row[i] ?? { text: "" };
+        const span = document.createElement("span");
+        span.className = "terminal-cell";
+        if (cell.tone) span.dataset.tone = cell.tone;
+        if (cell.align) span.dataset.align = cell.align;
+        span.textContent = cell.text;
+        grid.appendChild(span);
+      }
+    }
+    return grid;
+  }
+
+  /** Builds a titled, optionally tinted group wrapping its nested body blocks. */
+  private buildSection(block: Extract<Block, { type: "section" }>): HTMLElement {
+    const section = document.createElement("section");
+    section.className = "terminal-section";
+    if (block.tone) section.dataset.tone = block.tone;
+
+    if (block.title) {
+      const title = document.createElement("div");
+      title.className = "terminal-section-title";
+      title.textContent = block.title;
+      section.appendChild(title);
+    }
+
+    for (const child of block.body) section.appendChild(this.buildBlock(child));
+    return section;
   }
 }

--- a/v2-blog/src/_helpers/terminal/session.ts
+++ b/v2-blog/src/_helpers/terminal/session.ts
@@ -21,10 +21,30 @@ export const SESSION_KEY = "book_os:session";
  */
 export const SESSION_VERSION = 2;
 
+/** sessionStorage flag marking that the boot sequence has shown this session. */
+export const BOOT_KEY = "book_os:booted";
+
 /** Persisted command-history snapshot. */
 interface HistorySnapshot {
   v: number;
   history: string[];
+}
+
+/**
+ * Whether the terminal's boot flavour should show: true on the first summon of
+ * the browser session, false thereafter (it records the flag on the first call).
+ *
+ * @param storage - Backing store (defaults to `sessionStorage`).
+ * @returns `true` exactly once per session.
+ */
+export function takeFirstBootOfSession(storage: Storage = sessionStorage): boolean {
+  try {
+    if (storage.getItem(BOOT_KEY) !== null) return false;
+    storage.setItem(BOOT_KEY, "1");
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/v2-blog/src/_helpers/terminal/site-index.ts
+++ b/v2-blog/src/_helpers/terminal/site-index.ts
@@ -1,3 +1,5 @@
+import type { Block, Cell } from "./blocks.ts";
+
 /** Built URL of the site index manifest. */
 const SITE_INDEX_URL = "/assets/site-index.json";
 
@@ -98,6 +100,29 @@ export function renderRootListing(root: TreeNode): string[] {
     ...folders.map((f) => `${f.name}/   ${f.count}`),
     ...leaves.map((l) => l.name),
   ];
+}
+
+/**
+ * Builds the bare-`ls` listing as a structured block: a tinted section wrapping
+ * a two-column grid — folders (`name/` + a muted, right-aligned count) first,
+ * then leaf pages. Lets the terminal render aligned columns instead of flat text.
+ *
+ * @param root - The tree root.
+ * @returns A section block for {@link TerminalCore.render}.
+ */
+export function rootListingBlock(root: TreeNode): Block {
+  const folders = root.children.filter(isFolder);
+  const leaves = root.children.filter((n) => !isFolder(n));
+
+  const rows: Cell[][] = [
+    ...folders.map((f): Cell[] => [
+      { text: `${f.name}/` },
+      { text: String(f.count), tone: "muted", align: "end" },
+    ]),
+    ...leaves.map((l): Cell[] => [{ text: l.name }]),
+  ];
+
+  return { type: "section", title: "~/book_os", tone: "surface", body: [{ type: "columns", rows }] };
 }
 
 /** Renders a folder/leaf label: folders show `name/   count`, leaves `name`. */

--- a/v2-blog/src/_helpers/theme.ts
+++ b/v2-blog/src/_helpers/theme.ts
@@ -1,0 +1,73 @@
+/**
+ * Shared theme state (issue #81). The single source of truth for the site's
+ * `pinky` / `dark` themes, used by both `<theme-toggle>` and the terminal's
+ * `theme` command so the two never diverge. Switching dispatches a
+ * `theme-change` event other surfaces listen for to update their own UI.
+ */
+
+/** The two site themes; the value doubles as the stored string and class. */
+export type Theme = "pinky" | "dark";
+
+/** localStorage key holding the chosen theme (shared with the legacy toggle). */
+export const THEME_STORAGE_KEY = "theme";
+
+/** Window event dispatched on every theme change, with `{ theme }` detail. */
+export const THEME_CHANGE_EVENT = "theme-change";
+
+/** Whether a value is a valid theme. */
+function isTheme(value: unknown): value is Theme {
+  return value === "pinky" || value === "dark";
+}
+
+/**
+ * The stored theme, or null when absent/invalid.
+ *
+ * @returns The saved theme or null.
+ */
+export function getStoredTheme(): Theme | null {
+  let saved: string | null = null;
+  try {
+    saved = localStorage.getItem(THEME_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+  return isTheme(saved) ? saved : null;
+}
+
+/**
+ * The effective theme: the saved choice, else the system colour-scheme.
+ *
+ * @returns The theme to render.
+ */
+export function getTheme(): Theme {
+  const saved = getStoredTheme();
+  if (saved) return saved;
+  return window.matchMedia?.("(prefers-color-scheme: dark)")?.matches ? "dark" : "pinky";
+}
+
+/**
+ * Applies a theme to the document (no persistence, no event).
+ *
+ * @param theme - The theme to apply.
+ */
+export function applyTheme(theme: Theme): void {
+  const root = document.documentElement;
+  root.dataset.theme = theme;
+  root.classList.toggle("dark", theme === "dark");
+}
+
+/**
+ * Sets the theme everywhere: persists it, applies it to the document, and
+ * notifies listeners via {@link THEME_CHANGE_EVENT}.
+ *
+ * @param theme - The theme to switch to.
+ */
+export function setTheme(theme: Theme): void {
+  try {
+    localStorage.setItem(THEME_STORAGE_KEY, theme);
+  } catch {
+    // storage unavailable — still apply for this page view
+  }
+  applyTheme(theme);
+  window.dispatchEvent(new CustomEvent(THEME_CHANGE_EVENT, { detail: { theme } }));
+}

--- a/v2-blog/src/_includes/css/terminal.css
+++ b/v2-blog/src/_includes/css/terminal.css
@@ -51,6 +51,7 @@ html {
   --term-prompt: var(--color-accent-primary);
   --term-ok-bg: #2fa46a;
   --term-err-bg: #e5484d;
+  --term-warn-bg: #c8860d;
   --term-badge-text: #fff;
 }
 
@@ -76,6 +77,7 @@ html.dark {
   --term-on-accent: var(--color-gray-900);
   --term-ok-bg: #46d18a;
   --term-err-bg: #ff6b6b;
+  --term-warn-bg: #ffc857;
   --term-badge-text: #15131f;
 }
 

--- a/v2-blog/src/assets/styles/global.css
+++ b/v2-blog/src/assets/styles/global.css
@@ -112,6 +112,7 @@
     --term-prompt: var(--color-accent-primary);
     --term-ok-bg: #2fa46a;
     --term-err-bg: #e5484d;
+    --term-warn-bg: #c8860d;
     --term-badge-text: #fff;
   }
 
@@ -148,6 +149,7 @@
     --term-on-accent: var(--color-gray-900);
     --term-ok-bg: #46d18a;
     --term-err-bg: #ff6b6b;
+    --term-warn-bg: #ffc857;
     --term-badge-text: #15131f;
 
     --color-h1: var(--color-accent-primary);

--- a/v2-blog/src/components/terminal-overlay.ts
+++ b/v2-blog/src/components/terminal-overlay.ts
@@ -7,7 +7,7 @@ import {
   buildTree,
   fetchSiteIndex,
   findNode,
-  renderRootListing,
+  rootListingBlock,
   renderSubtree,
   resolveOpen,
   sanitizeNavQuery,
@@ -248,6 +248,69 @@ export class TerminalOverlay extends LitElement {
       #overlay-status { display: none; }
     }
 
+    /* Structured blocks: columns grid, tone chips, and sections. */
+    .terminal-cols {
+      display: grid;
+      gap: 0.1rem 1.5ch;
+      margin: 0.15rem 0;
+    }
+
+    .terminal-cell {
+      white-space: pre;
+    }
+
+    .terminal-cell[data-align="end"] {
+      justify-self: end;
+      text-align: right;
+    }
+
+    [data-tone="muted"] {
+      color: var(--term-muted);
+    }
+    [data-tone="accent"] {
+      background: var(--term-accent);
+      color: var(--term-on-accent);
+    }
+    [data-tone="ok"] {
+      background: var(--term-ok-bg);
+      color: var(--term-badge-text);
+    }
+    [data-tone="err"] {
+      background: var(--term-err-bg);
+      color: var(--term-badge-text);
+    }
+    [data-tone="warn"] {
+      background: var(--term-warn-bg);
+      color: var(--term-badge-text);
+    }
+    [data-tone="surface"] {
+      background: var(--term-surface);
+    }
+
+    /* Toned cells read as chips; muted/default stay text-only. */
+    .terminal-cell[data-tone="accent"],
+    .terminal-cell[data-tone="ok"],
+    .terminal-cell[data-tone="err"],
+    .terminal-cell[data-tone="warn"] {
+      padding: 0 0.6ch;
+      border-radius: 3px;
+    }
+
+    .terminal-section {
+      margin: 0.35rem 0;
+      padding: 0.6rem 0.8rem;
+      border-radius: 6px;
+    }
+
+    .terminal-section-title {
+      font-size: 0.78em;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--term-muted);
+      margin-bottom: 0.35rem;
+    }
+
     .sr-only {
       position: absolute;
       width: 1px;
@@ -421,9 +484,8 @@ export class TerminalOverlay extends LitElement {
     const target = sanitizeNavQuery(ctx.positionals[0] ?? "");
 
     if (!target) {
-      for (const line of renderRootListing(root)) {
-        await this._core.append(line, 0.02, CommandType.log);
-      }
+      // Structured: a tinted section with an aligned two-column grid.
+      await this._core.render(rootListingBlock(root));
       return;
     }
 

--- a/v2-blog/src/components/terminal-overlay.ts
+++ b/v2-blog/src/components/terminal-overlay.ts
@@ -12,7 +12,10 @@ import {
   resolveOpen,
   sanitizeNavQuery,
 } from "../_helpers/terminal/site-index.ts";
-import { TerminalSession } from "../_helpers/terminal/session.ts";
+import { takeFirstBootOfSession, TerminalSession } from "../_helpers/terminal/session.ts";
+import { playFirstSummonChime } from "../_helpers/terminal/chime.ts";
+import { getTheme, setTheme, type Theme } from "../_helpers/theme.ts";
+import { IdentityManager, IDMode } from "../_helpers/identityManager.ts";
 
 /**
  * Site-wide summonable terminal — an accessible modal window (issue #93).
@@ -274,10 +277,11 @@ export class TerminalOverlay extends LitElement {
       help: async (ctx: ParsedCommand) => {
         await this._core.append(ctx.raw, 0.2, CommandType.command);
         await this._core.append(
-          "help - list commands\nls [folder] - browse the site tree (blog, books, …)\nopen <slug> - go to a page\nexit / q - close the terminal",
+          "help - list commands\nls [folder] - browse the site tree (blog, books, …)\nopen <slug> - go to a page\ntheme [dark|pinky] - switch the theme\nwhoami - who are you, really\nexit / q - close the terminal",
           0.3,
           CommandType.logdata
         );
+        await this._core.append("psst — this is a cheat console. the classics still work.", 0.2, CommandType.logdata);
       },
 
       ls: async (ctx: ParsedCommand) => this._listContent(ctx),
@@ -285,6 +289,25 @@ export class TerminalOverlay extends LitElement {
 
       exit: async (ctx: ParsedCommand) => this._exit(ctx),
       q: async (ctx: ParsedCommand) => this._exit(ctx),
+
+      theme: async (ctx: ParsedCommand) => this._theme(ctx),
+      whoami: async (ctx: ParsedCommand) => {
+        await this._core.append(ctx.raw, 0.2, CommandType.command);
+        await this._core.append(
+          IdentityManager.getInstance().getFullIdentity(IDMode.default),
+          0.2,
+          CommandType.logdata
+        );
+      },
+
+      rosebud: async (ctx: ParsedCommand) => {
+        await this._core.append(ctx.raw, 0.2, CommandType.command);
+        await this._core.append("you bought one more book, your TBR thanks you", 0.2, CommandType.status);
+      },
+      motherlode: async (ctx: ParsedCommand) => {
+        await this._core.append(ctx.raw, 0.2, CommandType.command);
+        await this._core.append("all the books in the world and not enough time to read them", 0.2, CommandType.status);
+      },
 
       open: async (ctx: ParsedCommand) => {
         await this._core.append(ctx.raw, 0.2, CommandType.command);
@@ -332,6 +355,57 @@ export class TerminalOverlay extends LitElement {
   private async _exit(ctx: ParsedCommand): Promise<void> {
     await this._core.append(ctx.raw, 0.2, CommandType.command);
     this.open = false;
+  }
+
+  /**
+   * `theme [dark|pinky]` — no arg toggles; an explicit value sets it. Routes
+   * through the shared theme helper so the toggle component stays in sync.
+   *
+   * @param ctx - The parsed command (optional first positional is the target).
+   * @returns A promise that settles once the result is written.
+   */
+  private async _theme(ctx: ParsedCommand): Promise<void> {
+    await this._core.append(ctx.raw, 0.2, CommandType.command);
+    const arg = (ctx.positionals[0] ?? "").toLowerCase();
+
+    let next: Theme;
+    if (!arg) {
+      next = getTheme() === "dark" ? "pinky" : "dark";
+    } else if (arg === "dark") {
+      next = "dark";
+    } else if (arg === "pinky" || arg === "light") {
+      next = "pinky";
+    } else {
+      await this._core.append(`theme: unknown "${arg}" — try: dark, pinky`, 0.2, CommandType.error);
+      return;
+    }
+
+    setTheme(next);
+    await this._core.append(`theme → ${next}`, 0.2, CommandType.status);
+  }
+
+  /**
+   * Shows the per-session boot flavour: a couple of cheat-console lines with
+   * the Sims "reticulating splines" homage, pointing at `help`.
+   *
+   * @returns A promise that settles once the boot lines are written.
+   */
+  private async _boot(): Promise<void> {
+    await this._core.append("book_os v1.0 — cheat console", 0.2, CommandType.log);
+    await this._core.append("reticulating splines... ok", 0.2, CommandType.status);
+    await this._core.append("type `help` for commands", 0.2, CommandType.logdata);
+  }
+
+  /**
+   * Reward + flavour on summon: the per-session boot lines (first summon of the
+   * session) and the once-ever chime. Both gate themselves; calling on every
+   * open is safe.
+   *
+   * @returns `void`.
+   */
+  private _onOpened(): void {
+    if (takeFirstBootOfSession()) void this._boot();
+    playFirstSummonChime();
   }
 
   /**
@@ -389,6 +463,7 @@ export class TerminalOverlay extends LitElement {
     if (changed.has("open")) {
       if (this.open) {
         this._showModal();
+        this._onOpened();
       } else if (changed.get("open")) {
         this._closeModal();
       }

--- a/v2-blog/src/components/terminal-overlay.ts
+++ b/v2-blog/src/components/terminal-overlay.ts
@@ -15,7 +15,7 @@ import {
 import { takeFirstBootOfSession, TerminalSession } from "../_helpers/terminal/session.ts";
 import { playFirstSummonChime } from "../_helpers/terminal/chime.ts";
 import { getTheme, setTheme, type Theme } from "../_helpers/theme.ts";
-import { IdentityManager, IDMode } from "../_helpers/identityManager.ts";
+import { getIdentity } from "../_helpers/identity.ts";
 
 /**
  * Site-wide summonable terminal — an accessible modal window (issue #93).
@@ -293,11 +293,8 @@ export class TerminalOverlay extends LitElement {
       theme: async (ctx: ParsedCommand) => this._theme(ctx),
       whoami: async (ctx: ParsedCommand) => {
         await this._core.append(ctx.raw, 0.2, CommandType.command);
-        await this._core.append(
-          IdentityManager.getInstance().getFullIdentity(IDMode.default),
-          0.2,
-          CommandType.logdata
-        );
+        // Read fresh each run so it reflects a name chosen on the home page.
+        await this._core.append(getIdentity(), 0.2, CommandType.logdata);
       },
 
       rosebud: async (ctx: ParsedCommand) => {

--- a/v2-blog/src/components/theme-toggle.ts
+++ b/v2-blog/src/components/theme-toggle.ts
@@ -1,14 +1,12 @@
 import { LitElement, html, css, PropertyValues } from 'lit';
-import { customElement, property, state } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
 import { adoptTailwind } from "../_helpers/styleLoader.ts";
+import { applyTheme, getStoredTheme, setTheme, THEME_CHANGE_EVENT, type Theme } from "../_helpers/theme.ts";
 
 const THEMES = {
   pinky: "pinky",
   dark: "dark",
 } as const;
-
-type Theme = typeof THEMES[keyof typeof THEMES];
-const STORAGE_KEY = "theme";
 
 @customElement('theme-toggle')
 export class ThemeToggle extends LitElement {
@@ -24,6 +22,7 @@ export class ThemeToggle extends LitElement {
   constructor() {
     super();
     this._onSystemChange = this._onSystemChange.bind(this);
+    this._onThemeChange = this._onThemeChange.bind(this);
   }
 
   static styles = css`
@@ -55,11 +54,15 @@ export class ThemeToggle extends LitElement {
   connectedCallback() {
     super.connectedCallback();
     this._initThemeState();
+    // Stay in sync when another surface (e.g. the terminal `theme` command)
+    // changes the theme via the shared helper.
+    window.addEventListener(THEME_CHANGE_EVENT, this._onThemeChange);
   }
 
   disconnectedCallback() {
     super.disconnectedCallback();
     this._mql?.removeEventListener("change", this._onSystemChange);
+    window.removeEventListener(THEME_CHANGE_EVENT, this._onThemeChange);
   }
 
   async firstUpdated() {
@@ -72,9 +75,17 @@ export class ThemeToggle extends LitElement {
 
   protected updated(changedProperties: PropertyValues) {
     if (changedProperties.has('theme')) {
-      localStorage.setItem(STORAGE_KEY, this.theme);
+      // Persist + apply + notify other surfaces through the shared helper.
+      setTheme(this.theme);
+    }
+  }
 
-      this._applyThemeToDocument(this.theme);
+  /** Adopts a theme set elsewhere (via the shared `theme-change` event). */
+  private _onThemeChange(e: Event) {
+    const next = (e as CustomEvent<{ theme: Theme }>).detail?.theme;
+    if ((next === THEMES.dark || next === THEMES.pinky) && next !== this.theme) {
+      this._hasUserOverridden = true;
+      this.theme = next;
     }
   }
 
@@ -132,9 +143,9 @@ export class ThemeToggle extends LitElement {
 
   private _initThemeState() {
     this._mql = window.matchMedia("(prefers-color-scheme: dark)");
-    const saved = localStorage.getItem(STORAGE_KEY) as Theme | null;
+    const saved = getStoredTheme();
 
-    if (saved && (saved === THEMES.dark || saved === THEMES.pinky)) {
+    if (saved) {
       this.theme = saved;
       this._hasUserOverridden = true; // Saved implies previous user choice
     } else {
@@ -142,12 +153,6 @@ export class ThemeToggle extends LitElement {
       this._mql.addEventListener("change", this._onSystemChange);
     }
 
-    this._applyThemeToDocument(this.theme);
-  }
-
-  private _applyThemeToDocument(theme: Theme) {
-    const root = document.documentElement;
-    root.dataset.theme = theme;
-    root.classList.toggle("dark", theme === THEMES.dark);
+    applyTheme(this.theme);
   }
 }

--- a/v2-blog/src/components/user-fake-id.ts
+++ b/v2-blog/src/components/user-fake-id.ts
@@ -1,7 +1,8 @@
 import { css, html, LitElement, nothing, PropertyValues } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 
-import { IdentityManager, IDMode } from "../_helpers/identityManager.ts";
+import { IdentityManager } from "../_helpers/identityManager.ts";
+import { getIdentity, nextRandomIdentity, setIdentity } from "../_helpers/identity.ts";
 
 @customElement('user-fakeid')
 export class UserFakeID extends LitElement {
@@ -104,7 +105,7 @@ export class UserFakeID extends LitElement {
     }
 
     if (this._userElID) {
-      this.userID = this.identity.getFullIdentity(IDMode.default);
+      this.userID = getIdentity();
     }
   }
 
@@ -122,15 +123,14 @@ export class UserFakeID extends LitElement {
 
   private async _handleRandomID(): Promise<void> {
     this.isRandom = true;
-    console.log(this.identity.getFullIdentity(IDMode.random));
-
-    this.userID = this.identity.getFullIdentity(IDMode.random);
+    this.userID = nextRandomIdentity();
     await this.identity.animateReveal(this._userElID, this.userID);
   }
 
   private setRandomID(): void {
     if (!this.userID) return;
-    this.identity.cacheName(this.userID);
+    // Persist + broadcast so other surfaces (e.g. the terminal `whoami`) agree.
+    setIdentity(this.userID);
   }
 
   protected render(): unknown {

--- a/v2-blog/tests/e2e/terminal-overlay.spec.ts
+++ b/v2-blog/tests/e2e/terminal-overlay.spec.ts
@@ -128,6 +128,42 @@ test("unlock: visiting the books page reveals the site-wide terminal button", as
   await expect(page.locator("terminal-overlay")).toHaveAttribute("open", "");
 });
 
+test("first summon shows the boot flavour and arms the once-ever chime", async ({ page }) => {
+  await page.goto("/");
+  await page.keyboard.press("Control+Shift+C");
+  await expect(page.locator("#overlay-input")).toBeFocused();
+
+  await expect(page.locator("#overlay-log")).toContainText("reticulating splines");
+  // The chime path ran (synthesized via Web Audio) and set its persistent flag.
+  expect(await page.evaluate(() => localStorage.getItem("book_os:chimed"))).not.toBeNull();
+});
+
+test("reduced motion: the chime does not play (no flag set)", async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await page.goto("/");
+  await page.keyboard.press("Control+Shift+C");
+  await expect(page.locator("#overlay-input")).toBeFocused();
+
+  // Boot text still shows, but the chime is skipped and its flag stays unset.
+  await expect(page.locator("#overlay-log")).toContainText("reticulating splines");
+  expect(await page.evaluate(() => localStorage.getItem("book_os:chimed"))).toBeNull();
+});
+
+test("the theme command switches the theme and syncs the header toggle", async ({ page }) => {
+  await page.goto("/");
+  await page.keyboard.press("Control+Shift+C");
+  await expect(page.locator("#overlay-input")).toBeFocused();
+
+  await page.locator("#overlay-input").fill("theme dark");
+  await page.keyboard.press("Enter");
+
+  await expect.poll(() => page.evaluate(() => document.documentElement.classList.contains("dark"))).toBe(true);
+
+  // The header toggle synced to the new theme via the shared theme-change
+  // event (its reflected `theme` attribute flips) — no divergent state.
+  await expect(page.locator('theme-toggle[theme="dark"]').first()).toBeAttached();
+});
+
 test("mobile: summoning from the drawer closes the drawer and opens the modal", async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 800 });
 

--- a/v2-blog/tests/e2e/terminal-overlay.spec.ts
+++ b/v2-blog/tests/e2e/terminal-overlay.spec.ts
@@ -128,14 +128,14 @@ test("unlock: visiting the books page reveals the site-wide terminal button", as
   await expect(page.locator("terminal-overlay")).toHaveAttribute("open", "");
 });
 
-test("first summon shows the boot flavour and arms the once-ever chime", async ({ page }) => {
+test("first summon shows the boot flavour and arms the per-session chime", async ({ page }) => {
   await page.goto("/");
   await page.keyboard.press("Control+Shift+C");
   await expect(page.locator("#overlay-input")).toBeFocused();
 
   await expect(page.locator("#overlay-log")).toContainText("reticulating splines");
-  // The chime path ran (synthesized via Web Audio) and set its persistent flag.
-  expect(await page.evaluate(() => localStorage.getItem("book_os:chimed"))).not.toBeNull();
+  // The chime path ran (synthesized via Web Audio) and set its per-session flag.
+  expect(await page.evaluate(() => sessionStorage.getItem("book_os:chimed"))).not.toBeNull();
 });
 
 test("reduced motion: the chime does not play (no flag set)", async ({ page }) => {
@@ -146,7 +146,7 @@ test("reduced motion: the chime does not play (no flag set)", async ({ page }) =
 
   // Boot text still shows, but the chime is skipped and its flag stays unset.
   await expect(page.locator("#overlay-log")).toContainText("reticulating splines");
-  expect(await page.evaluate(() => localStorage.getItem("book_os:chimed"))).toBeNull();
+  expect(await page.evaluate(() => sessionStorage.getItem("book_os:chimed"))).toBeNull();
 });
 
 test("the theme command switches the theme and syncs the header toggle", async ({ page }) => {

--- a/v2-blog/tests/unit/components/terminal-overlay.test.ts
+++ b/v2-blog/tests/unit/components/terminal-overlay.test.ts
@@ -17,6 +17,7 @@ vi.mock("../../../src/_helpers/styleLoader.ts", () => ({
 
 import { TerminalOverlay } from "../../../src/components/terminal-overlay.ts";
 import { TerminalSession } from "../../../src/_helpers/terminal/session.ts";
+import { setIdentity } from "../../../src/_helpers/identity.ts";
 
 async function mountOverlay() {
   const el = new TerminalOverlay();
@@ -226,6 +227,18 @@ describe("terminal-overlay", () => {
       submit(el, "whoami");
       await flush();
       expect($(el, "#overlay-log")!.textContent).toMatch(/::/);
+    });
+
+    it("whoami reflects an identity chosen elsewhere (not the seed default)", async () => {
+      setIdentity("ghost_reader::4242");
+
+      const el = await mountOverlay();
+      el.open = true;
+      await el.updateComplete;
+
+      submit(el, "whoami");
+      await flush();
+      expect($(el, "#overlay-log")!.textContent).toContain("ghost_reader::4242");
     });
 
     it("responds to the rosebud and motherlode easter eggs", async () => {

--- a/v2-blog/tests/unit/components/terminal-overlay.test.ts
+++ b/v2-blog/tests/unit/components/terminal-overlay.test.ts
@@ -42,6 +42,7 @@ async function flush() {
 beforeEach(() => {
   document.body.innerHTML = "";
   sessionStorage.clear();
+  localStorage.clear();
 });
 
 describe("terminal-overlay", () => {
@@ -151,6 +152,97 @@ describe("terminal-overlay", () => {
     });
   });
 
+  describe("delight package (#81)", () => {
+    it("shows the boot flavour on the first summon of the session", async () => {
+      const el = await mountOverlay();
+      el.open = true;
+      await el.updateComplete;
+      await flush();
+
+      expect($(el, "#overlay-log")!.textContent).toContain("reticulating splines");
+    });
+
+    it("does not boot again on a later summon in the same session", async () => {
+      // First element consumes the per-session boot flag.
+      const first = await mountOverlay();
+      first.open = true;
+      await first.updateComplete;
+      await flush();
+
+      // A fresh element (e.g. after navigation) must not re-boot.
+      document.body.innerHTML = "";
+      const second = await mountOverlay();
+      second.open = true;
+      await second.updateComplete;
+      await flush();
+
+      expect($(second, "#overlay-log")!.textContent).not.toContain("reticulating splines");
+    });
+
+    it("help hints that cheats exist without listing them", async () => {
+      const el = await mountOverlay();
+      el.open = true;
+      await el.updateComplete;
+      submit(el, "help");
+      await flush();
+
+      const text = $(el, "#overlay-log")!.textContent!;
+      expect(text).toContain("cheat console");
+      expect(text).not.toContain("rosebud");
+    });
+
+    it("theme switches and persists, and toggles with no argument", async () => {
+      const el = await mountOverlay();
+      el.open = true;
+      await el.updateComplete;
+
+      submit(el, "theme dark");
+      await flush();
+      expect(document.documentElement.classList.contains("dark")).toBe(true);
+      expect(localStorage.getItem("theme")).toBe("dark");
+
+      submit(el, "theme");
+      await flush();
+      expect(document.documentElement.classList.contains("dark")).toBe(false);
+      expect(localStorage.getItem("theme")).toBe("pinky");
+    });
+
+    it("rejects an unknown theme argument", async () => {
+      const el = await mountOverlay();
+      el.open = true;
+      await el.updateComplete;
+
+      submit(el, "theme neon");
+      await flush();
+      expect($(el, "#overlay-log")!.textContent).toMatch(/neon|unknown|usage/i);
+      expect(localStorage.getItem("theme")).not.toBe("neon");
+    });
+
+    it("whoami prints the generated identity", async () => {
+      const el = await mountOverlay();
+      el.open = true;
+      await el.updateComplete;
+
+      submit(el, "whoami");
+      await flush();
+      expect($(el, "#overlay-log")!.textContent).toMatch(/::/);
+    });
+
+    it("responds to the rosebud and motherlode easter eggs", async () => {
+      const el = await mountOverlay();
+      el.open = true;
+      await el.updateComplete;
+
+      submit(el, "rosebud");
+      await flush();
+      expect($(el, "#overlay-log")!.textContent).toContain("TBR");
+
+      submit(el, "motherlode");
+      await flush();
+      expect($(el, "#overlay-log")!.textContent).toContain("not enough time");
+    });
+  });
+
   describe("command history (persists across navigations, not scrollback)", () => {
     it("recalls prior commands with ArrowUp/ArrowDown", async () => {
       const el = await mountOverlay();
@@ -186,8 +278,9 @@ describe("terminal-overlay", () => {
     });
 
     it("rehydrates history from the session on mount, but starts with an empty log", async () => {
-      // Simulate a prior page in the same tab having run a command.
+      // Simulate a prior page in the same tab having run a command (and booted).
       new TerminalSession().writeHistory(["open ring"]);
+      sessionStorage.setItem("book_os:booted", "1"); // suppress the boot flavour
 
       const el = await mountOverlay();
       el.open = true;

--- a/v2-blog/tests/unit/helpers/identity.test.ts
+++ b/v2-blog/tests/unit/helpers/identity.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  getIdentity,
+  IDENTITY_CHANGE_EVENT,
+  setIdentity,
+} from "../../../src/_helpers/identity.ts";
+
+beforeEach(() => {
+  sessionStorage.clear();
+});
+
+describe("identity helper", () => {
+  it("falls back to a generated identity when none is chosen", () => {
+    expect(getIdentity()).toMatch(/::\d{4}$/);
+  });
+
+  it("returns the chosen identity once one is set", () => {
+    setIdentity("ghost_reader::4242");
+    expect(getIdentity()).toBe("ghost_reader::4242");
+  });
+
+  it("setIdentity dispatches an identity-change event with the new value", () => {
+    const seen: string[] = [];
+    const listener = (e: Event) => seen.push((e as CustomEvent<{ identity: string }>).detail.identity);
+    window.addEventListener(IDENTITY_CHANGE_EVENT, listener);
+
+    setIdentity("void_daemon::0001");
+
+    expect(seen).toEqual(["void_daemon::0001"]);
+    window.removeEventListener(IDENTITY_CHANGE_EVENT, listener);
+  });
+
+  it("reflects the latest chosen identity on each read (whoami stays current)", () => {
+    setIdentity("a::1111");
+    expect(getIdentity()).toBe("a::1111");
+    setIdentity("b::2222");
+    expect(getIdentity()).toBe("b::2222");
+  });
+});

--- a/v2-blog/tests/unit/helpers/terminal/chime.test.ts
+++ b/v2-blog/tests/unit/helpers/terminal/chime.test.ts
@@ -69,7 +69,7 @@ describe("playFirstSummonChime", () => {
     expect(storage.getItem(CHIME_KEY)).not.toBeNull();
   });
 
-  it("never plays a second time (once ever per profile)", () => {
+  it("never plays a second time in the same session", () => {
     const createAudioContext = vi.fn(() => fakeAudioContext() as unknown as AudioContext);
     const deps = { storage, prefersReducedMotion: () => false, createAudioContext };
 

--- a/v2-blog/tests/unit/helpers/terminal/chime.test.ts
+++ b/v2-blog/tests/unit/helpers/terminal/chime.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CHIME_KEY, playFirstSummonChime } from "../../../../src/_helpers/terminal/chime.ts";
+
+/** Minimal in-memory Storage stand-in. */
+function fakeStorage(): Storage {
+  const map = new Map<string, string>();
+  return {
+    get length() {
+      return map.size;
+    },
+    clear: () => map.clear(),
+    getItem: (k) => (map.has(k) ? map.get(k)! : null),
+    key: (i) => [...map.keys()][i] ?? null,
+    removeItem: (k) => void map.delete(k),
+    setItem: (k, v) => void map.set(k, v),
+  };
+}
+
+/** A spyable AudioContext stub good enough for the synth graph. */
+function fakeAudioContext() {
+  const osc = {
+    type: "",
+    frequency: { setValueAtTime: vi.fn() },
+    connect: vi.fn(),
+    start: vi.fn(),
+    stop: vi.fn(),
+  };
+  const gain = {
+    gain: {
+      setValueAtTime: vi.fn(),
+      linearRampToValueAtTime: vi.fn(),
+      exponentialRampToValueAtTime: vi.fn(),
+    },
+    connect: vi.fn(),
+  };
+  return {
+    currentTime: 0,
+    destination: {},
+    state: "running",
+    resume: vi.fn(),
+    createOscillator: vi.fn(() => osc),
+    createGain: vi.fn(() => gain),
+    _osc: osc,
+    _gain: gain,
+  };
+}
+
+let storage: Storage;
+
+beforeEach(() => {
+  storage = fakeStorage();
+});
+
+describe("playFirstSummonChime", () => {
+  it("plays once and records the persistent flag", () => {
+    const ctx = fakeAudioContext();
+    const createAudioContext = vi.fn(() => ctx as unknown as AudioContext);
+
+    const played = playFirstSummonChime({
+      storage,
+      prefersReducedMotion: () => false,
+      createAudioContext,
+    });
+
+    expect(played).toBe(true);
+    expect(createAudioContext).toHaveBeenCalledTimes(1);
+    expect(ctx.createOscillator).toHaveBeenCalled(); // it built the graph
+    expect(storage.getItem(CHIME_KEY)).not.toBeNull();
+  });
+
+  it("never plays a second time (once ever per profile)", () => {
+    const createAudioContext = vi.fn(() => fakeAudioContext() as unknown as AudioContext);
+    const deps = { storage, prefersReducedMotion: () => false, createAudioContext };
+
+    expect(playFirstSummonChime(deps)).toBe(true);
+    expect(playFirstSummonChime(deps)).toBe(false);
+    expect(createAudioContext).toHaveBeenCalledTimes(1);
+  });
+
+  it("is skipped under prefers-reduced-motion and does not consume the flag", () => {
+    const createAudioContext = vi.fn(() => fakeAudioContext() as unknown as AudioContext);
+
+    const played = playFirstSummonChime({
+      storage,
+      prefersReducedMotion: () => true,
+      createAudioContext,
+    });
+
+    expect(played).toBe(false);
+    expect(createAudioContext).not.toHaveBeenCalled();
+    expect(storage.getItem(CHIME_KEY)).toBeNull(); // a later non-reduced visit can still chime
+  });
+
+  it("no-ops without consuming the flag when Web Audio is unavailable", () => {
+    const played = playFirstSummonChime({
+      storage,
+      prefersReducedMotion: () => false,
+      createAudioContext: () => null,
+    });
+
+    expect(played).toBe(false);
+    expect(storage.getItem(CHIME_KEY)).toBeNull();
+  });
+});

--- a/v2-blog/tests/unit/helpers/terminal/core.test.ts
+++ b/v2-blog/tests/unit/helpers/terminal/core.test.ts
@@ -78,6 +78,59 @@ describe("TerminalCore", () => {
     expect(logEl.querySelectorAll("p")).toHaveLength(2);
   });
 
+  describe("render (structured blocks)", () => {
+    it("renders a text block as a classed paragraph (with a badge for badged kinds)", async () => {
+      const { core, logEl } = createCore();
+
+      await core.render({ type: "text", text: "hi there", kind: CommandType.status });
+
+      const p = logEl.querySelector("p.terminal-msg.status")!;
+      expect(p.textContent).toBe("hi there");
+      expect(p.getAttribute("data-badge")).toBe("OK");
+    });
+
+    it("renders a columns block as a grid with tone/align on cells, padding short rows", async () => {
+      const { core, logEl } = createCore();
+
+      await core.render({
+        type: "columns",
+        rows: [
+          [{ text: "blog/" }, { text: "3", tone: "muted", align: "end" }],
+          [{ text: "about" }],
+        ],
+      });
+
+      const grid = logEl.querySelector(".terminal-cols") as HTMLElement;
+      expect(grid).not.toBeNull();
+      // 2 columns inferred from the widest row; short row padded to 2 cells.
+      const cells = grid.querySelectorAll(".terminal-cell");
+      expect(cells).toHaveLength(4);
+      expect(grid.style.gridTemplateColumns).toContain("repeat(2");
+
+      const count = cells[1] as HTMLElement;
+      expect(count.textContent).toBe("3");
+      expect(count.dataset.tone).toBe("muted");
+      expect(count.dataset.align).toBe("end");
+    });
+
+    it("renders a section with a title, tone, and nested body", async () => {
+      const { core, logEl } = createCore();
+
+      await core.render({
+        type: "section",
+        title: "site",
+        tone: "surface",
+        body: [{ type: "text", text: "inside" }],
+      });
+
+      const section = logEl.querySelector("section.terminal-section") as HTMLElement;
+      expect(section).not.toBeNull();
+      expect(section.dataset.tone).toBe("surface");
+      expect(section.querySelector(".terminal-section-title")!.textContent).toBe("site");
+      expect(section.querySelector("p.terminal-msg")!.textContent).toBe("inside");
+    });
+  });
+
   it("passes each written line's text and kind to onLineWritten", async () => {
     const onLineWritten = vi.fn();
     const { core } = createCore({ onLineWritten });

--- a/v2-blog/tests/unit/helpers/terminal/session.test.ts
+++ b/v2-blog/tests/unit/helpers/terminal/session.test.ts
@@ -1,6 +1,12 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
-import { SESSION_KEY, SESSION_VERSION, TerminalSession } from "../../../../src/_helpers/terminal/session.ts";
+import {
+  BOOT_KEY,
+  SESSION_KEY,
+  SESSION_VERSION,
+  takeFirstBootOfSession,
+  TerminalSession,
+} from "../../../../src/_helpers/terminal/session.ts";
 
 /** Minimal in-memory Storage stand-in (decoupled from jsdom globals). */
 function fakeStorage(): Storage {
@@ -67,5 +73,16 @@ describe("TerminalSession (command-history persistence)", () => {
       expectEmpty(JSON.stringify({ v: SESSION_VERSION, history: "ls" }));
       expectEmpty(JSON.stringify({ v: SESSION_VERSION, history: [1, 2] }));
     });
+  });
+});
+
+describe("takeFirstBootOfSession", () => {
+  it("returns true once per session, then false, and records the flag", () => {
+    const storage = fakeStorage();
+
+    expect(takeFirstBootOfSession(storage)).toBe(true);
+    expect(storage.getItem(BOOT_KEY)).not.toBeNull();
+    expect(takeFirstBootOfSession(storage)).toBe(false);
+    expect(takeFirstBootOfSession(storage)).toBe(false);
   });
 });

--- a/v2-blog/tests/unit/helpers/terminal/site-index.test.ts
+++ b/v2-blog/tests/unit/helpers/terminal/site-index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { buildTree, findNode, matchEntry, parseSiteIndex, renderRootListing, renderSubtree, resolveOpen, sanitizeNavQuery } from "../../../../src/_helpers/terminal/site-index.ts";
+import { buildTree, findNode, matchEntry, parseSiteIndex, renderRootListing, rootListingBlock, renderSubtree, resolveOpen, sanitizeNavQuery } from "../../../../src/_helpers/terminal/site-index.ts";
 
 const ENTRIES = parseSiteIndex([
   { section: "posts", title: "Why I never heard of Lit", url: "/blog/2025/why-i-never-heard-of-lit/" },
@@ -159,6 +159,32 @@ describe("renderRootListing", () => {
 
     // folders come before leaves
     expect(lines.findIndex((l) => l.startsWith("blog/"))).toBeLessThan(lines.indexOf("about"));
+  });
+});
+
+describe("rootListingBlock", () => {
+  it("is a surface section wrapping a columns grid: folders (name + muted count) before leaves", () => {
+    const block = rootListingBlock(buildTree(ENTRIES));
+
+    expect(block.type).toBe("section");
+    if (block.type !== "section") return;
+    expect(block.tone).toBe("surface");
+
+    const cols = block.body[0];
+    expect(cols.type).toBe("columns");
+    if (cols.type !== "columns") return;
+
+    const blogRow = cols.rows.find((r) => r[0].text === "blog/")!;
+    expect(blogRow[1].text).toBe("3");
+    expect(blogRow[1].tone).toBe("muted");
+    expect(blogRow[1].align).toBe("end");
+
+    const aboutRow = cols.rows.find((r) => r[0].text === "about")!;
+    expect(aboutRow).toBeDefined();
+
+    const blogIdx = cols.rows.findIndex((r) => r[0].text === "blog/");
+    const aboutIdx = cols.rows.findIndex((r) => r[0].text === "about");
+    expect(blogIdx).toBeLessThan(aboutIdx);
   });
 });
 

--- a/v2-blog/tests/unit/helpers/theme.test.ts
+++ b/v2-blog/tests/unit/helpers/theme.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  applyTheme,
+  getTheme,
+  setTheme,
+  THEME_CHANGE_EVENT,
+  THEME_STORAGE_KEY,
+} from "../../../src/_helpers/theme.ts";
+
+function stubSystemDark(enabled: boolean) {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: query.includes("prefers-color-scheme") ? enabled : false,
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })),
+  });
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  document.documentElement.removeAttribute("data-theme");
+  document.documentElement.classList.remove("dark");
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("theme helper", () => {
+  it("applyTheme sets the document data-theme and dark class", () => {
+    applyTheme("dark");
+    expect(document.documentElement.dataset.theme).toBe("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+
+    applyTheme("pinky");
+    expect(document.documentElement.dataset.theme).toBe("pinky");
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+  });
+
+  it("setTheme persists, applies, and dispatches a theme-change event", () => {
+    const seen: string[] = [];
+    const listener = (e: Event) => seen.push((e as CustomEvent<{ theme: string }>).detail.theme);
+    window.addEventListener(THEME_CHANGE_EVENT, listener);
+
+    setTheme("dark");
+
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(seen).toEqual(["dark"]);
+
+    window.removeEventListener(THEME_CHANGE_EVENT, listener);
+  });
+
+  it("getTheme returns the saved theme when valid", () => {
+    localStorage.setItem(THEME_STORAGE_KEY, "dark");
+    expect(getTheme()).toBe("dark");
+  });
+
+  it("getTheme falls back to the system preference when nothing is saved", () => {
+    stubSystemDark(true);
+    expect(getTheme()).toBe("dark");
+
+    stubSystemDark(false);
+    expect(getTheme()).toBe("pinky");
+  });
+
+  it("getTheme ignores an invalid saved value", () => {
+    localStorage.setItem(THEME_STORAGE_KEY, "neon");
+    stubSystemDark(false);
+    expect(getTheme()).toBe("pinky");
+  });
+});


### PR DESCRIPTION
Closes #81

Three related chunks landed on this branch (kept together per review preference).

## 1 — Delight package (#81)

- **First-summon chime** (`chime.ts`): synthesized ascending arpeggio via Web Audio (no asset/request), **skipped under `prefers-reduced-motion`**.
- **Per-session boot**: "reticulating splines" cheat-console flavour on the first summon of a session.
- **Commands**: `theme` (toggle / `dark` / `pinky`), `whoami`, and `rosebud` / `motherlode` easter eggs; `help` hints cheats exist.
- **Shared `theme.ts`**: `getTheme`/`setTheme`/`applyTheme` + `theme-change` event; `theme-toggle` refactored to use it (no divergent state).

## 2 — Follow-up fixes

- **`whoami` reflected**: it ignored the name chosen on the home page (it regenerated from the seed). New shared `identity.ts` (`getIdentity`/`setIdentity` + `identity-change` event); `whoami` and `user-fakeid` both route through it, so the chosen identity stays consistent.
- **Chime cadence**: moved from a once-ever `localStorage` boolean to a **once-per-session** `sessionStorage` flag, so it greets again on a new visit.

## 3 — Structured log output

- **`blocks.ts`**: descriptor model — `text` / `columns` / `section` with a semantic **tone palette** (`default/muted/accent/ok/err/surface/warn`) mapped to `--term-*` tokens (added `--term-warn-bg`). No hard-coded colours; themeable + CSP-clean.
- **`core.render(block)`**: builds structured DOM instantly (alongside the flat `append`).
- **`ls`** now prints as a tinted `surface` section wrapping an aligned two-column grid (folder + muted, right-aligned count) via `site-index.rootListingBlock`.

## Testing

- Unit: 163 pass (chime/boot/theme/identity helpers, `core.render`, `rootListingBlock`, all commands). Typecheck + lint clean (0 errors).
- e2e: 12/12 (boot+chime armed, reduced-motion skip, theme sync, modal/unlock/nav suite).
- Manual (chrome-devtools MCP): boot + easter eggs + `theme dark`; `whoami` reflects a home-page-chosen name; structured `ls` columns/section/tones — screenshots in both themes.