### PR TITLE
feat(theme): top-down view-transition sweep on theme switch

### DIFF
--- a/v2-blog/CLAUDE.md
+++ b/v2-blog/CLAUDE.md
@@ -85,3 +85,5 @@ Both layouts build the `Content-Security-Policy` meta tag **at build time** by h
 - Changing a page's `permalink` can break the Lighthouse route list (`.lighthouserc*.json`) and the frontmatter tests.
 - Don't edit `dist/` — it's build output.
 - Component lifecycle: cleanup in `disconnectedCallback` must mirror setup (listeners, observers, rAF, timers, GSAP handles).
+- Dev-server watch doesn't track TS imports: editing only a `src/_helpers/*.ts` file does **not** rebuild the component bundles that import it — `touch` the importing `src/components/*.ts` file (or restart the server) and verify the change actually landed in `dist/` before browser-testing.
+- Multiple `<theme-toggle>` instances echo through `setTheme` via the `theme-change` event — any side effect added to the theme path must be idempotent under same-tick repeat calls (see the `pendingTheme` guard in `_helpers/theme.ts`).

--- a/v2-blog/src/_helpers/theme.ts
+++ b/v2-blog/src/_helpers/theme.ts
@@ -57,6 +57,58 @@ export function applyTheme(theme: Theme): void {
 }
 
 /**
+ * Runs `applyTheme` inside a top-down clip-path view transition when the
+ * browser supports the View Transitions API and the user hasn't asked for
+ * reduced motion. Otherwise applies the theme instantly (current behaviour).
+ *
+ * @param theme - The theme to switch to.
+ */
+/** Theme currently being applied by a running view transition, if any. */
+let pendingTheme: Theme | null = null;
+
+function applyThemeAnimated(theme: Theme): void {
+  const root = document.documentElement;
+
+  // Theme already applied or mid-swap — this is an echo (e.g. a second
+  // <theme-toggle> re-broadcasting through setTheme after the theme-change
+  // event). Starting another view transition would skip the running one and
+  // yank the .theme-vt class off mid-sweep, so bail before animating.
+  // `pendingTheme` is needed because applyTheme runs inside the async view
+  // transition callback, so dataset.theme is still stale when echoes arrive.
+  if (root.dataset.theme === theme || pendingTheme === theme) return;
+
+  const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+  if (!document.startViewTransition || prefersReducedMotion) {
+    applyTheme(theme);
+    return;
+  }
+
+  pendingTheme = theme;
+  root.classList.add("theme-vt");
+
+  const transition = document.startViewTransition(() => applyTheme(theme));
+  transition.finished.finally(() => {
+    // Only clean up if a newer swap hasn't taken over (rapid re-toggle skips
+    // this transition, and its own finally must not undo the newer one).
+    if (pendingTheme === theme) {
+      pendingTheme = null;
+      root.classList.remove("theme-vt");
+    }
+  });
+  transition.ready
+    .then(() => {
+      root.animate(
+        { clipPath: ["inset(0 0 100% 0)", "inset(0)"] },
+        { pseudoElement: "::view-transition-new(root)", duration: 600, easing: "ease" }
+      );
+    })
+    .catch(() => {
+      // Transition skipped (e.g. another swap interrupted it) — theme already applied.
+    });
+}
+
+/**
  * Sets the theme everywhere: persists it, applies it to the document, and
  * notifies listeners via {@link THEME_CHANGE_EVENT}.
  *
@@ -68,6 +120,6 @@ export function setTheme(theme: Theme): void {
   } catch {
     // storage unavailable — still apply for this page view
   }
-  applyTheme(theme);
+  applyThemeAnimated(theme);
   window.dispatchEvent(new CustomEvent(THEME_CHANGE_EVENT, { detail: { theme } }));
 }

--- a/v2-blog/src/assets/styles/global.css
+++ b/v2-blog/src/assets/styles/global.css
@@ -215,6 +215,37 @@
   animation: var(--animate-fade-in);
 }
 
+/* Theme swap (scoped to .theme-vt, toggled by setTheme in _helpers/theme.ts).
+   Kill the default root cross-fade so only the top-down clip-path sweep plays.
+   Scoping keeps page-navigation's root crossfade untouched. */
+:root.theme-vt::view-transition-new(root) {
+  animation: none;
+  mix-blend-mode: normal;
+}
+
+:root.theme-vt::view-transition-old(root) {
+  animation: none;
+}
+
+/* During the swap: (1) freeze live CSS transitions so the VT snapshot captures
+   the fully-swapped theme instead of elements mid-transition; (2) drop
+   will-change promotion (main + .dotted-bg use will-change:opacity) so those
+   composited layers fold back into the single root snapshot and ride the sweep
+   — otherwise only the un-promoted header/footer animate. */
+:root.theme-vt *,
+:root.theme-vt *::before,
+:root.theme-vt *::after {
+  transition: none !important;
+  will-change: auto !important;
+}
+
+/* <main> carries view-transition-name:post for the page-nav morph. During a
+   theme swap that name would split main into its own (fading) group instead of
+   the root clip — drop it so the whole page sweeps as one root snapshot. */
+:root.theme-vt main {
+  view-transition-name: none;
+}
+
 .logo {
   position: relative;
   padding-inline-end: calc(var(--spacing)*2.5);


### PR DESCRIPTION
Wrap applyTheme in startViewTransition with a clip-path reveal (inset top-down, 600ms). Falls back to instant swap when the API is missing or prefers-reduced-motion is set.

- scope root crossfade override to .theme-vt so page-nav VT is untouched
- freeze transitions/will-change during the swap so the snapshot captures the fully-swapped theme
- drop main's view-transition-name during theme swaps so it rides the root sweep instead of fading in its own group
- guard setTheme against same-tick echoes from multiple theme-toggle instances (each re-broadcast used to skip the running transition)