### PR TITLE
refactor(preview): deepen media-preview into coordinator + leaf modules

### DIFF
--- a/v2-blog/src/_helpers/previewChannels.ts
+++ b/v2-blog/src/_helpers/previewChannels.ts
@@ -1,0 +1,144 @@
+import type { MediaType } from './sharedPreview.ts';
+
+/**
+ * A media channel is the per-type playback element behind the shared preview
+ * bubble (ADR 0004). One adapter per {@link MediaType} concentrates everything
+ * that used to fork on the type across the singleton — element creation, the
+ * blur-in (`is-loaded`) wiring, the `visible` toggle, and play/pause.
+ *
+ * The singleton holds one channel per type and keeps exactly one *active* at a
+ * time; switching means `deactivate()` the old, `activate()` the new. Reveal-
+ * only images have no-op play/pause; audio has no-op activate/deactivate (its
+ * imagery is the wrapper's `data-kind` vinyl, not the element).
+ */
+export interface MediaChannel {
+  readonly type: MediaType;
+  /** The element to append into the bubble wrapper. */
+  readonly el: HTMLElement;
+  /** Point the channel at a source, resetting the blur-in until it loads. */
+  load(src: string): void;
+  /** Reveal this channel's element (`visible`). */
+  activate(): void;
+  /** Hide it. */
+  deactivate(): void;
+  /** Start playback (no-op for images). */
+  play(): Promise<void> | void;
+  /** Pause playback (no-op for images; guarded for media). */
+  pause(): void;
+}
+
+const VISIBLE = 'visible';
+const LOADED = 'is-loaded';
+
+/** Static image. No playback; the blur-in clears on decode (or error). */
+export class ImageChannel implements MediaChannel {
+  readonly type = 'image';
+  readonly el: HTMLImageElement;
+
+  constructor() {
+    this.el = document.createElement('img');
+    // Blur-in: CSS keeps fresh media blurred until `is-loaded` lands; `error`
+    // also marks it so a failed load never leaves a permanently frosted bubble.
+    const markLoaded = () => this.el.classList.add(LOADED);
+    this.el.addEventListener('load', markLoaded);
+    this.el.addEventListener('error', markLoaded);
+  }
+
+  load(src: string): void {
+    if (this.el.src === src) return;
+    this.el.classList.remove(LOADED);
+    this.el.src = src;
+    // Cached image: no load event will fire, mark it ready at once.
+    if (this.el.complete && this.el.naturalWidth > 0) this.el.classList.add(LOADED);
+  }
+
+  activate(): void {
+    this.el.classList.add(VISIBLE);
+  }
+
+  deactivate(): void {
+    this.el.classList.remove(VISIBLE);
+  }
+
+  play(): void {}
+  pause(): void {}
+}
+
+/** Muted, looping, silent clip. Reveals a paused first frame; plays on commit. */
+export class VideoChannel implements MediaChannel {
+  readonly type = 'video';
+  readonly el: HTMLVideoElement;
+
+  constructor() {
+    this.el = document.createElement('video');
+    this.el.muted = true;
+    this.el.loop = true;
+    this.el.playsInline = true;
+    this.el.preload = 'auto';
+    const markLoaded = () => this.el.classList.add(LOADED);
+    // Setting src resets readyState, so `canplay` re-marks it — even for cached clips.
+    this.el.addEventListener('canplay', markLoaded);
+    this.el.addEventListener('error', markLoaded);
+  }
+
+  load(src: string): void {
+    if (this.el.src === src) return;
+    this.el.classList.remove(LOADED);
+    this.el.src = src;
+  }
+
+  activate(): void {
+    this.el.classList.add(VISIBLE);
+  }
+
+  deactivate(): void {
+    this.el.classList.remove(VISIBLE);
+  }
+
+  play(): Promise<void> {
+    return this.el.play();
+  }
+
+  pause(): void {
+    if (!this.el.paused) this.el.pause();
+  }
+}
+
+/** Looping album audio. No visual — the wrapper's `data-kind` vinyl is the imagery. */
+export class AudioChannel implements MediaChannel {
+  readonly type = 'audio';
+  readonly el: HTMLAudioElement;
+
+  constructor() {
+    this.el = document.createElement('audio');
+    this.el.loop = true;
+    this.el.preload = 'auto';
+  }
+
+  load(src: string): void {
+    if (this.el.src === src) return;
+    this.el.src = src;
+  }
+
+  activate(): void {}
+  deactivate(): void {}
+
+  play(): Promise<void> {
+    return this.el.play();
+  }
+
+  pause(): void {
+    if (!this.el.paused) this.el.pause();
+  }
+}
+
+export type MediaChannels = Record<MediaType, MediaChannel>;
+
+/** Builds one channel per media type, ready to append into the bubble wrapper. */
+export function createMediaChannels(): MediaChannels {
+  return {
+    image: new ImageChannel(),
+    video: new VideoChannel(),
+    audio: new AudioChannel(),
+  };
+}

--- a/v2-blog/src/_helpers/previewGeometry.ts
+++ b/v2-blog/src/_helpers/previewGeometry.ts
@@ -1,0 +1,112 @@
+/**
+ * Pure positioning geometry for the media-preview bubble (ADR 0004).
+ *
+ * Extracted from the `SharedMediaPreview` singleton so the subtlest logic — the
+ * 4-way anchor switch and the horizontal-clamp / vertical-unclamp trailing rule
+ * — is testable without a DOM, a real `window`, or a full playback scenario.
+ * This module is a leaf: it never touches `window`, the singleton, or the DOM.
+ * Callers pass the viewport in and write the returned `{x, y}` to CSS vars.
+ */
+
+/**
+ * Offset in pixels between the bubble and its anchor (cursor or trigger rect).
+ * Keeps the cursor visible and the bubble off the viewport edges.
+ */
+export const PREVIEW_OFFSET = 12;
+
+export type PreviewPlacement = 'cursor' | 'top' | 'bottom' | 'left' | 'right';
+
+export interface PreviewSize {
+  w: number;
+  h: number;
+}
+
+export interface Viewport {
+  width: number;
+  height: number;
+}
+
+export interface PositionInput {
+  placement: PreviewPlacement;
+  /** Trigger rect to anchor beside. Null → cursor-center (cursor placement) or
+   *  viewport-center (anchored placement). */
+  triggerRect: DOMRect | null;
+  cursor: { x: number; y: number };
+  size: PreviewSize;
+  viewport: Viewport;
+  /** Skip the vertical clamp so the bubble can trail its source off-screen. */
+  unclampY?: boolean;
+}
+
+/**
+ * Computes the top-left `{x, y}` for the preview bubble.
+ *
+ * Contract, disambiguated by `placement`:
+ * - `placement: 'cursor'` → centered on the cursor (clamped to the viewport).
+ * - anchored placement (`top`/`bottom`/`left`/`right`) **with** a rect → offset
+ *   beside that rect, clamped.
+ * - anchored placement **without** a rect → centered in the viewport, *unclamped*
+ *   (the play-commit fallback when no trigger rect was captured).
+ *
+ * Horizontal is always clamped so a right-anchored bubble never flies off a
+ * full-width mobile card; vertical is clamped unless `unclampY`, which lets the
+ * bubble trail its source card off-screen 1:1 during touch scroll-follow.
+ */
+export function computePreviewPosition({
+  placement,
+  triggerRect,
+  cursor,
+  size,
+  viewport,
+  unclampY = false,
+}: PositionInput): { x: number; y: number } {
+  const { w, h } = size;
+  const { width: vw, height: vh } = viewport;
+
+  // Anchored placement but no rect: center in the viewport, unclamped — matches
+  // the singleton's old `_positionAnchored` fallback exactly.
+  if (!triggerRect && placement !== 'cursor') {
+    return { x: (vw - w) / 2, y: (vh - h) / 2 };
+  }
+
+  let x = 0;
+  let y = 0;
+
+  if (placement === 'cursor' || !triggerRect) {
+    // Center the bubble on the cursor.
+    x = cursor.x - w / 2;
+    y = cursor.y - h / 2;
+  } else {
+    const rect = triggerRect;
+    switch (placement) {
+      case 'right':
+        x = rect.right + PREVIEW_OFFSET;
+        y = rect.top + (rect.height - h) / 2;
+        break;
+      case 'left':
+        x = rect.left - w - PREVIEW_OFFSET;
+        y = rect.top + (rect.height - h) / 2;
+        break;
+      case 'top':
+        x = rect.left + (rect.width - w) / 2;
+        y = rect.top - h - PREVIEW_OFFSET;
+        break;
+      case 'bottom':
+        x = rect.left + (rect.width - w) / 2;
+        y = rect.bottom + PREVIEW_OFFSET;
+        break;
+    }
+  }
+
+  // Clamp so it doesn't overflow the viewport too badly. Horizontal always;
+  // vertical unless the caller is trailing the bubble off-screen.
+  const maxX = vw - w - PREVIEW_OFFSET;
+  const maxY = vh - h - PREVIEW_OFFSET;
+
+  x = Math.max(PREVIEW_OFFSET, Math.min(x, maxX));
+  if (!unclampY) {
+    y = Math.max(PREVIEW_OFFSET, Math.min(y, maxY));
+  }
+
+  return { x, y };
+}

--- a/v2-blog/src/_helpers/scrollAnchor.ts
+++ b/v2-blog/src/_helpers/scrollAnchor.ts
@@ -1,0 +1,55 @@
+/**
+ * Owns the window scroll/resize listener lifecycle for the media-preview bubble
+ * (ADR 0004). It attaches once (idempotent), rAF-throttles scroll into a single
+ * `onScrollFrame` per frame, forwards resize to `onResize`, and detaches +
+ * cancels the pending frame symmetrically on `stop()`.
+ *
+ * It holds **no policy**: the caller decides what each frame does (touch
+ * reposition / off-screen stop / desktop dismiss). This is the mechanical part
+ * — the bug-prone attach/cancel/cleanup — pulled out so it can be verified in
+ * isolation with a fake `window` and synthetic scroll events.
+ */
+export interface ScrollAnchorHooks {
+  /** Called at most once per animation frame while scrolling. */
+  onScrollFrame(): void;
+  /** Called on every resize (not throttled — resize fires far less often). */
+  onResize(): void;
+}
+
+export class ScrollAnchor {
+  private _on = false;
+  private _raf: number | null = null;
+
+  private _onScroll = (): void => {
+    if (this._raf !== null) return;
+    this._raf = requestAnimationFrame(() => {
+      this._raf = null;
+      this._hooks.onScrollFrame();
+    });
+  };
+
+  private _onResize = (): void => this._hooks.onResize();
+
+  constructor(private _hooks: ScrollAnchorHooks) {}
+
+  /** Attaches the window listeners. Idempotent — a second call is a no-op. */
+  start(): void {
+    if (this._on || typeof window === 'undefined') return;
+    window.addEventListener('scroll', this._onScroll, { passive: true });
+    window.addEventListener('resize', this._onResize, { passive: true });
+    this._on = true;
+  }
+
+  /** Detaches the listeners and cancels any pending animation frame. */
+  stop(): void {
+    if (this._on && typeof window !== 'undefined') {
+      window.removeEventListener('scroll', this._onScroll);
+      window.removeEventListener('resize', this._onResize);
+    }
+    this._on = false;
+    if (this._raf !== null) {
+      cancelAnimationFrame(this._raf);
+      this._raf = null;
+    }
+  }
+}

--- a/v2-blog/src/_helpers/sharedPreview.ts
+++ b/v2-blog/src/_helpers/sharedPreview.ts
@@ -69,28 +69,33 @@ interface PositionOptions {
  */
 type RectProvider = () => DOMRect;
 
-interface ShowOptions extends PositionOptions {
+/**
+ * Everything the singleton needs to identify and locate a trigger card. The
+ * card hands this over; the singleton pulls the rect, derives the coordinates,
+ * and applies the `'cursor' → 'right'` anchor coercion itself — the card no
+ * longer speaks the positioning vocabulary (ADR 0004).
+ */
+export interface PreviewTrigger {
   src: string;
   type?: MediaType;
   kind?: MediaKind;
+  /** The card's positioning strategy. Coerced to 'right' when anchored/grown. */
+  placement: PreviewPlacement;
+  /** Live rect of the card — read for anchoring and touch scroll-follow. */
+  getRect: RectProvider;
+}
+
+/** Per-interaction reveal intent, layered over a {@link PreviewTrigger}. */
+export interface RevealOptions {
+  /** Desktop pointer position; absent for focus/scroll (centre on the rect). */
+  cursor?: { x: number; y: number };
   /**
    * Skip the hover-intent sampler and reveal at once. For interactions where
    * intent is proven by the gesture itself (keyboard focus, touch scroll-in).
    */
   immediate?: boolean;
-  /** Touch only: live rect provider so the glimpse tracks the card on scroll. */
-  getRect?: RectProvider;
-}
-
-interface PlayOptions {
-  src: string;
-  type?: MediaType;
-  kind?: MediaKind;
-  /** The trigger's rect — playback anchors the grown bubble beside it. */
-  triggerRect?: DOMRect | null;
-  placement?: PreviewPlacement;
-  /** Touch only: live rect provider so the grown bubble tracks the card on scroll. */
-  getRect?: RectProvider;
+  /** Anchor beside the card instead of on the cursor (touch scroll-reveal). */
+  anchor?: boolean;
 }
 
 /**
@@ -98,9 +103,9 @@ interface PlayOptions {
  *
  * ONE shared DOM node, reused for every trigger (ADR 0004). It is purely
  * decorative (`aria-hidden`, `pointer-events: none`) — all interaction lives on
- * the trigger card, which drives this via `show()` (reveal a paused glimpse),
- * `togglePlay()` (commit to playback: anchor + grow + start media), and
- * `stop()` / `hide()`.
+ * the trigger card, which drives this by handing over a {@link PreviewTrigger}:
+ * `reveal()` (reveal a paused glimpse), `commit()` (anchor + grow + start
+ * media), and `move()` / `stop()` / `hide()`.
  */
 export class SharedMediaPreview {
   /** Window event fired (with `{ detail: { src } }`) whenever playback stops. */
@@ -246,38 +251,44 @@ export class SharedMediaPreview {
   }
 
   /**
-   * Reveals a paused glimpse at specific coordinates. NEVER starts playback
-   * (ADR 0004: reveal ≠ play). If a different media is currently playing,
-   * hovering here stops it and retargets the single bubble to this glimpse.
+   * Reveals a paused glimpse for a trigger. NEVER starts playback (ADR 0004:
+   * reveal ≠ play). The singleton pulls the rect from the trigger and derives
+   * the coordinates: with a `cursor` it centres there, otherwise on the rect's
+   * centre; `anchor` beside the card (touch scroll-reveal). If a different media
+   * is currently playing, revealing here stops it and retargets the bubble.
    */
-  show({ src, type, kind, x, y, placement = 'cursor', triggerRect, immediate = false, getRect }: ShowOptions): void {
+  reveal(trigger: PreviewTrigger, { cursor, immediate = false, anchor = false }: RevealOptions = {}): void {
+    const { src } = trigger;
     if (!src) return;
 
-    // Determine type: use provided type or try to guess from file extension
-    const effectiveType = type || this.inferType(src);
+    const effectiveType = trigger.type || this.inferType(src);
     if (!effectiveType) return;
     this._ensureAttached();
+
+    const rect = trigger.getRect();
+    const placement = anchor ? this._anchorPlacementFor(trigger.placement) : trigger.placement;
+    const point = cursor ?? { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
 
     // The card that committed to playback owns the grown bubble — approaching it
     // again must not shrink it back to a glimpse.
     if (this._isPlaying && this._currentSrc === src) return;
 
-    // Hovering a different card while one plays: stop it, then reveal this
+    // Revealing a different card while one plays: stop it, then reveal this
     // glimpse (retarget the single bubble).
     if (this._isPlaying) {
       this._stopPlayback();
     }
 
-    this._applyMeta(effectiveType, kind, GLIMPSE_SIZE);
+    this._applyMeta(effectiveType, trigger.kind, GLIMPSE_SIZE);
 
     this._anchorPlacement = placement;
-    this._cursor = { x, y };
-    this._setPosition({ x, y, placement, triggerRect });
+    this._cursor = point;
+    this._setPosition({ x: point.x, y: point.y, placement, triggerRect: rect });
 
     // Touch: keep the glimpse glued to its card as the page scrolls. Desktop
-    // glimpses follow the cursor instead, so no rect provider is passed.
-    if (getRect && this._coarsePointer()) {
-      this._startTracking(getRect);
+    // glimpses follow the cursor instead.
+    if (this._coarsePointer()) {
+      this._startTracking(trigger.getRect);
     }
 
     // Warm: bubble already up (or lingering) — intent stays proven, siblings
@@ -294,6 +305,11 @@ export class SharedMediaPreview {
     this._startIntent(src, effectiveType);
   }
 
+  /** Grown/anchored placement never sits on the cursor: 'cursor' becomes 'right'. */
+  private _anchorPlacementFor(placement: PreviewPlacement): PreviewPlacement {
+    return placement === 'cursor' ? 'right' : placement;
+  }
+
   /**
    * Commits to (or ends) playback for a trigger. Toggle semantics: calling it
    * for the media already playing stops it; otherwise it anchors the bubble
@@ -302,10 +318,11 @@ export class SharedMediaPreview {
    *
    * @returns the resulting playing state (true = now playing).
    */
-  togglePlay({ src, type, kind, triggerRect, placement = 'right', getRect }: PlayOptions): boolean {
+  commit(trigger: PreviewTrigger): boolean {
+    const { src } = trigger;
     if (!src) return false;
 
-    const effectiveType = type || this.inferType(src);
+    const effectiveType = trigger.type || this.inferType(src);
     if (!effectiveType) return false;
 
     // Reveal-only types never enter the playing state.
@@ -324,12 +341,16 @@ export class SharedMediaPreview {
     this._cancelIntent();
     this._cancelLinger();
 
+    const rect = trigger.getRect();
+    // Grown playback always anchors beside the card, never on the cursor.
+    const placement = this._anchorPlacementFor(trigger.placement);
+
     // Load the media (glimpse first frame) then start it, grown + anchored.
-    this._applyMeta(effectiveType, kind, this._grownSize());
+    this._applyMeta(effectiveType, trigger.kind, this._grownSize());
     this._reveal(src, effectiveType);
 
     this._isPlaying = true;
-    this._anchorRect = triggerRect ?? null;
+    this._anchorRect = rect;
     this._anchorPlacement = placement;
     this._wrapper.classList.add('is-playing', 'is-grown');
 
@@ -340,7 +361,7 @@ export class SharedMediaPreview {
     // Desktop: any real scroll dismisses playback (no follow), so we only need
     // the listener and the baseline scroll position.
     if (this._coarsePointer()) {
-      this._startTracking(getRect ?? null);
+      this._startTracking(trigger.getRect);
     } else {
       this._playStartScrollY = this._scrollY();
       this._startTracking(null);
@@ -538,14 +559,14 @@ export class SharedMediaPreview {
   }
 
   /**
-   * Updates the position of the preview element during mousemove. No-op while
+   * Repositions the glimpse to a new cursor point during mousemove. No-op while
    * playback is committed — the grown bubble stays anchored to its trigger.
    */
-  move({ x, y, placement = 'cursor', triggerRect }: PositionOptions): void {
+  move(trigger: PreviewTrigger, cursor: { x: number; y: number }): void {
     if (this._isPlaying) return;
     this._ensureAttached();
-    this._cursor = { x, y };
-    this._setPosition({ x, y, placement, triggerRect });
+    this._cursor = cursor;
+    this._setPosition({ x: cursor.x, y: cursor.y, placement: trigger.placement, triggerRect: trigger.getRect() });
   }
 
   /**

--- a/v2-blog/src/_helpers/sharedPreview.ts
+++ b/v2-blog/src/_helpers/sharedPreview.ts
@@ -4,6 +4,7 @@ import {
   type PreviewPlacement,
   type PreviewSize,
 } from './previewGeometry.ts';
+import { ScrollAnchor } from './scrollAnchor.ts';
 
 export type { PreviewPlacement } from './previewGeometry.ts';
 
@@ -135,19 +136,14 @@ export class SharedMediaPreview {
   // --- Touch scroll-follow / desktop dismiss-on-scroll ---
   /** Live rect of the current source card (touch only); null when not tracking. */
   private _trackGetRect: RectProvider | null = null;
-  private _trackListenersOn = false;
-  private _scrollRaf: number | null = null;
   private _trackIdleTimer: ReturnType<typeof setTimeout> | null = null;
   /** Scroll position captured at desktop play time, for the dismiss threshold. */
   private _playStartScrollY = 0;
-  private _onScroll = (): void => {
-    if (this._scrollRaf !== null) return;
-    this._scrollRaf = requestAnimationFrame(() => {
-      this._scrollRaf = null;
-      this._onScrollFrame();
-    });
-  };
-  private _onResize = (): void => this._reposition();
+  /** Owns the scroll/resize listener + rAF lifecycle; policy stays here. */
+  private _scrollAnchor = new ScrollAnchor({
+    onScrollFrame: () => this._onScrollFrame(),
+    onResize: () => this._reposition(),
+  });
 
   /**
    * Retrieves the singleton instance of SharedMediaPreview.
@@ -410,24 +406,13 @@ export class SharedMediaPreview {
    */
   private _startTracking(getRect: RectProvider | null): void {
     this._trackGetRect = getRect;
-    if (this._trackListenersOn || typeof window === 'undefined') return;
-    window.addEventListener('scroll', this._onScroll, { passive: true });
-    window.addEventListener('resize', this._onResize, { passive: true });
-    this._trackListenersOn = true;
+    this._scrollAnchor.start();
   }
 
   /** Detaches scroll tracking and clears its transient state. */
   private _stopTracking(): void {
-    if (this._trackListenersOn && typeof window !== 'undefined') {
-      window.removeEventListener('scroll', this._onScroll);
-      window.removeEventListener('resize', this._onResize);
-    }
-    this._trackListenersOn = false;
+    this._scrollAnchor.stop();
     this._trackGetRect = null;
-    if (this._scrollRaf !== null) {
-      cancelAnimationFrame(this._scrollRaf);
-      this._scrollRaf = null;
-    }
     if (this._trackIdleTimer !== null) {
       clearTimeout(this._trackIdleTimer);
       this._trackIdleTimer = null;

--- a/v2-blog/src/_helpers/sharedPreview.ts
+++ b/v2-blog/src/_helpers/sharedPreview.ts
@@ -1,9 +1,11 @@
-/**
- * Offset in pixels to position the preview element relative to the cursor.
- * This ensures the cursor remains visible and prevents the preview
- * from interfering with mouse events on the underlying element.
- */
-const PREVIEW_OFFSET = 12;
+import {
+  PREVIEW_OFFSET,
+  computePreviewPosition,
+  type PreviewPlacement,
+  type PreviewSize,
+} from './previewGeometry.ts';
+
+export type { PreviewPlacement } from './previewGeometry.ts';
 
 /**
  * Hover intent (see CONTEXT.md): the preview only appears once the cursor
@@ -36,12 +38,6 @@ const TRACK_IDLE_MS = 120;
 
 export type MediaType = 'image' | 'video' | 'audio';
 export type MediaKind = 'album' | 'book' | 'game' | 'project';
-export type PreviewPlacement = 'cursor' | 'top' | 'bottom' | 'left' | 'right';
-
-interface PreviewSize {
-  w: number;
-  h: number;
-}
 
 /**
  * Two sizes, both circles (ADR 0004: circle always, grow on play). The glimpse
@@ -646,83 +642,32 @@ export class SharedMediaPreview {
    * viewport-centered if no rect was captured at play time.
    */
   private _positionAnchored(): void {
-    // Prefer the live rect (touch follow) over the play-time snapshot.
+    // Prefer the live rect (touch follow) over the play-time snapshot. A null
+    // rect with the anchored placement resolves to viewport-center inside
+    // `computePreviewPosition` (the play-commit fallback).
     const rect = this._trackGetRect?.() ?? this._anchorRect;
 
-    if (!rect) {
-      const { w, h } = this._currentSize;
-      // Center via cursor placement using viewport middle.
-      this._wrapper.style.setProperty('--preview-x', `${(window.innerWidth - w) / 2}px`);
-      this._wrapper.style.setProperty('--preview-y', `${(window.innerHeight - h) / 2}px`);
-      return;
-    }
-
     this._setPosition({
-      x: rect.left + rect.width / 2,
-      y: rect.top + rect.height / 2,
+      x: rect ? rect.left + rect.width / 2 : 0,
+      y: rect ? rect.top + rect.height / 2 : 0,
       placement: this._anchorPlacement,
       triggerRect: rect,
     });
   }
 
   /**
-   * Calculates and applies CSS variables for positioning.
-   * Applies an offset to center the preview relative to the cursor.
+   * Resolves the bubble position (pure geometry, see `previewGeometry.ts`) and
+   * writes it to the `--preview-x/y` CSS variables.
    */
-  private _setPosition({ x, y, placement, triggerRect, unclampY = false }: PositionOptions): void {
-    let eixoX = 0;
-    let eixoY = 0;
-
-    const vw = window.innerWidth;
-    const vh = window.innerHeight;
-    const { w, h } = this._currentSize;
-
-    if (placement === 'cursor' || !triggerRect) {
-      // center bubble on cursor
-      eixoX = x - w / 2;
-      eixoY = y - h / 2;
-    } else {
-      const rect = triggerRect;
-      switch (placement) {
-        case 'right':
-          eixoX = rect.right + PREVIEW_OFFSET;
-          eixoY = rect.top + (rect.height - h) / 2;
-          break;
-
-        case 'left':
-          eixoX = rect.left - w - PREVIEW_OFFSET;
-          eixoY = rect.top + (rect.height - h) / 2;
-          break;
-
-        case 'top':
-          eixoX = rect.left + (rect.width - w) / 2;
-          eixoY = rect.top - h - PREVIEW_OFFSET;
-          break;
-
-        case 'bottom':
-          eixoX = rect.left + (rect.width - w) / 2;
-          eixoY = rect.bottom + PREVIEW_OFFSET;
-          break;
-
-        default:
-          // fallback to cursor
-          eixoX = x - w / 2;
-          eixoY = y - h / 2;
-          break;
-      }
-    }
-
-    // Clamp so it doesn’t overflow viewport too badly. During touch follow the
-    // vertical clamp is skipped so the bubble can trail its card off-screen
-    // instead of pinning to an edge; horizontal stays clamped so the
-    // right-anchored bubble never flies off a full-width mobile card.
-    const maxX = vw - w - PREVIEW_OFFSET;
-    const maxY = vh - h - PREVIEW_OFFSET;
-
-    eixoX = Math.max(PREVIEW_OFFSET, Math.min(eixoX, maxX));
-    if (!unclampY) {
-      eixoY = Math.max(PREVIEW_OFFSET, Math.min(eixoY, maxY));
-    }
+  private _setPosition({ x, y, placement = 'cursor', triggerRect, unclampY = false }: PositionOptions): void {
+    const { x: eixoX, y: eixoY } = computePreviewPosition({
+      placement,
+      triggerRect: triggerRect ?? null,
+      cursor: { x, y },
+      size: this._currentSize,
+      viewport: { width: window.innerWidth, height: window.innerHeight },
+      unclampY,
+    });
 
     this._wrapper.style.setProperty('--preview-x', `${eixoX}px`);
     this._wrapper.style.setProperty('--preview-y', `${eixoY}px`);

--- a/v2-blog/src/_helpers/sharedPreview.ts
+++ b/v2-blog/src/_helpers/sharedPreview.ts
@@ -5,6 +5,7 @@ import {
   type PreviewSize,
 } from './previewGeometry.ts';
 import { ScrollAnchor } from './scrollAnchor.ts';
+import { type MediaChannel, createMediaChannels } from './previewChannels.ts';
 
 export type { PreviewPlacement } from './previewGeometry.ts';
 
@@ -116,9 +117,10 @@ export class SharedMediaPreview {
   private static instance: SharedMediaPreview;
 
   private _wrapper: HTMLDivElement;
-  private img: HTMLImageElement;
-  private video: HTMLVideoElement;
-  private audio: HTMLAudioElement;
+  /** One playback element per media type; exactly one is active at a time. */
+  private _channels = createMediaChannels();
+  /** The channel currently revealed in the bubble, if any. */
+  private _active: MediaChannel | null = null;
   private _currentSrc: string | null;
   private _currentType: MediaType | null;
   private _currentSize: PreviewSize;
@@ -157,9 +159,9 @@ export class SharedMediaPreview {
   }
 
   /**
-   * Initializes the shared DOM elements: a wrapper div holding an `img`, a
-   * `video`, and an `audio` element. Media is created paused — nothing plays
-   * until a trigger commits via `togglePlay()`.
+   * Initializes the bubble: a wrapper div holding one element per media channel
+   * (image / video / audio). Each channel creates and configures its own
+   * element (see `previewChannels.ts`); media is paused until a trigger commits.
    */
   private constructor() {
     /** The main container for the preview. */
@@ -168,33 +170,9 @@ export class SharedMediaPreview {
     // Purely decorative glimpse — the slotted trigger carries all semantics.
     this._wrapper.setAttribute('aria-hidden', 'true');
 
-    /** Element used to display static images. */
-    this.img = document.createElement('img');
-
-    /** Element used to display (muted, silent) video clips on commit. */
-    this.video = document.createElement('video');
-    // No autoplay: reveal shows a paused first frame; playback is committed.
-    this.video.muted = true;
-    this.video.loop = true;
-    this.video.playsInline = true;
-    this.video.preload = 'auto';
-
-    /** Element used to play audio previews (albums) on commit. */
-    this.audio = document.createElement('audio');
-    this.audio.loop = true;
-    this.audio.preload = 'auto';
-
-    // Blur-in: fresh media carries no `is-loaded` class and CSS keeps it
-    // blurred; the class lands when the data is actually there. `error` also
-    // marks it so a failed load never leaves a permanently frosted bubble.
-    this.img.addEventListener('load', () => this.img.classList.add('is-loaded'));
-    this.img.addEventListener('error', () => this.img.classList.add('is-loaded'));
-    this.video.addEventListener('canplay', () => this.video.classList.add('is-loaded'));
-    this.video.addEventListener('error', () => this.video.classList.add('is-loaded'));
-
-    this._wrapper.appendChild(this.img);
-    this._wrapper.appendChild(this.video);
-    this._wrapper.appendChild(this.audio);
+    for (const type of ['image', 'video', 'audio'] as const) {
+      this._wrapper.appendChild(this._channels[type].el);
+    }
     this._ensureAttached();
 
     /** Tracks the currently loaded source to avoid redundant reloading. */
@@ -528,14 +506,13 @@ export class SharedMediaPreview {
     const isSameMedia = this._currentSrc === src && this._currentType === type;
 
     if (!isSameMedia) {
-      if (type === 'video') {
-        this._loadVideo(src);
-      } else if (type === 'audio') {
-        this._loadAudio(src);
-      } else {
-        this._showImage(src);
-      }
+      const channel = this._channels[type];
+      // Exactly one channel is visible at a time: retire the outgoing one.
+      if (this._active && this._active !== channel) this._active.deactivate();
+      channel.load(src);
+      channel.activate();
 
+      this._active = channel;
       this._currentSrc = src;
       this._currentType = type;
     }
@@ -596,8 +573,7 @@ export class SharedMediaPreview {
     const wasPlaying = this._isPlaying;
     const stoppedSrc = this._currentSrc;
 
-    if (!this.video.paused) this.video.pause();
-    if (!this.audio.paused) this.audio.pause();
+    this._pauseAllMedia();
 
     this._isPlaying = false;
     this._anchorRect = null;
@@ -619,11 +595,9 @@ export class SharedMediaPreview {
     this._stopTracking();
     this._wrapper.classList.remove('is-visible');
 
-    this.img.classList.remove('visible');
-    this.video.classList.remove('visible');
-
-    if (!this.video.paused) this.video.pause();
-    if (!this.audio.paused) this.audio.pause();
+    this._active?.deactivate();
+    this._pauseAllMedia();
+    this._active = null;
 
     delete this._wrapper.dataset.kind;
 
@@ -631,16 +605,21 @@ export class SharedMediaPreview {
     this._currentType = null;
   }
 
-  /** Starts whichever media element matches the current type. */
-  private _startCurrentMedia(): void {
-    const el = this._currentType === 'video' ? this.video
-      : this._currentType === 'audio' ? this.audio
-        : null;
-    if (!el) return;
+  /** Pauses every channel's media (no-op for the image channel). */
+  private _pauseAllMedia(): void {
+    for (const type of ['image', 'video', 'audio'] as const) {
+      this._channels[type].pause();
+    }
+  }
 
-    el.play().catch((error) => {
-      console.warn('[SharedMediaPreview] Preview playback failed', error);
-    });
+  /** Starts playback on the active channel (a no-op for the image channel). */
+  private _startCurrentMedia(): void {
+    const result = this._active?.play();
+    if (result) {
+      result.catch((error) => {
+        console.warn('[SharedMediaPreview] Preview playback failed', error);
+      });
+    }
   }
 
   /**
@@ -677,55 +656,5 @@ export class SharedMediaPreview {
 
     this._wrapper.style.setProperty('--preview-x', `${eixoX}px`);
     this._wrapper.style.setProperty('--preview-y', `${eixoY}px`);
-  }
-
-  /**
-   * Internal helper to activate the image element and deactivate video.
-   */
-  private _showImage(src: string): void {
-    this.video.classList.remove('visible');
-    this.img.classList.add('visible');
-
-    // Only update DOM attribute if src actually changed to prevent flickering
-    if (this.img.src !== src) {
-      this.img.classList.remove('is-loaded');
-      this.img.src = src;
-
-      // Cached image: no load event will fire, mark it ready at once.
-      if (this.img.complete && this.img.naturalWidth > 0) {
-        this.img.classList.add('is-loaded');
-      }
-    }
-  }
-
-  /**
-   * Loads a video and shows its (paused) first frame. Playback is deferred to
-   * the commit step (`togglePlay`).
-   */
-  private _loadVideo(src: string): void {
-    this.img.classList.remove('visible');
-    this.video.classList.add('visible');
-
-    if (this.video.src !== src) {
-      // Setting src resets readyState, so `canplay` (wired in the
-      // constructor) re-marks it loaded — even for cached clips.
-      this.video.classList.remove('is-loaded');
-      this.video.src = src;
-    }
-  }
-
-  /**
-   * Loads an audio source. Audio has no visual — the wrapper's `data-kind`
-   * (e.g. album → vinyl) provides the imagery; playback is deferred to commit.
-   */
-  private _loadAudio(src: string): void {
-    // Audio carries no picture: the image element stays hidden, the vinyl (or
-    // bare accent circle) is the visual.
-    this.img.classList.remove('visible');
-    this.video.classList.remove('visible');
-
-    if (this.audio.src !== src) {
-      this.audio.src = src;
-    }
   }
 }

--- a/v2-blog/src/components/media-preview.ts
+++ b/v2-blog/src/components/media-preview.ts
@@ -1,6 +1,6 @@
 import { LitElement, html, css, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
-import { MediaKind, MediaType, PreviewPlacement, SharedMediaPreview } from "../_helpers/sharedPreview.ts";
+import { MediaKind, MediaType, PreviewPlacement, PreviewTrigger, SharedMediaPreview } from "../_helpers/sharedPreview.ts";
 
 /**
  * Touch scroll-reveal is coordinated across ALL <media-preview> cards by a
@@ -211,37 +211,31 @@ export class MediaPreview extends LitElement {
     return this.previewType === 'video' || this.previewType === 'audio';
   }
 
+  /**
+   * The trigger descriptor handed to the shared bubble. Carries the card's
+   * identity + a live rect provider; the bubble derives coordinates, placement,
+   * and scroll-follow from it (ADR 0004). Callers guard on `previewSrc` first.
+   */
+  private get _trigger(): PreviewTrigger {
+    return {
+      src: this.previewSrc as string,
+      type: this.previewType,
+      kind: this.mediaKind ?? undefined,
+      placement: this.previewPosition,
+      getRect: () => this.getBoundingClientRect(),
+    };
+  }
+
   // --- Desktop hover: reveal glimpse (paused) ---
 
   private _handleMouseEnter(e: MouseEvent) {
     if (this._isTouch || !this.previewSrc) return;
-
-    const preview = SharedMediaPreview.getInstance();
-    const rect = this.getBoundingClientRect();
-
-    preview.show({
-      src: this.previewSrc,
-      type: this.previewType,
-      kind: this.mediaKind ?? undefined,
-      x: e.clientX,
-      y: e.clientY,
-      placement: this.previewPosition,
-      triggerRect: rect,
-    });
+    SharedMediaPreview.getInstance().reveal(this._trigger, { cursor: { x: e.clientX, y: e.clientY } });
   }
 
   private _handleMouseMove(e: MouseEvent) {
     if (this._isTouch || !this.previewSrc) return;
-
-    const preview = SharedMediaPreview.getInstance();
-    const rect = this.getBoundingClientRect();
-
-    preview.move({
-      x: e.clientX,
-      y: e.clientY,
-      placement: this.previewPosition,
-      triggerRect: rect,
-    });
+    SharedMediaPreview.getInstance().move(this._trigger, { x: e.clientX, y: e.clientY });
   }
 
   private _handleMouseLeave() {
@@ -252,21 +246,8 @@ export class MediaPreview extends LitElement {
 
   private _handleFocusIn() {
     if (!this.previewSrc) return;
-
-    const preview = SharedMediaPreview.getInstance();
-    const rect = this.getBoundingClientRect();
-
-    preview.show({
-      src: this.previewSrc,
-      type: this.previewType,
-      kind: this.mediaKind ?? undefined,
-      x: rect.left + rect.width / 2,
-      y: rect.top + rect.height / 2,
-      placement: this.previewPosition,
-      triggerRect: rect,
-      // Tabbing to the trigger is intent by itself — no hover-intent sampling.
-      immediate: true,
-    });
+    // Tabbing to the trigger is intent by itself — no hover-intent sampling.
+    SharedMediaPreview.getInstance().reveal(this._trigger, { immediate: true });
   }
 
   private _handleFocusOut(e: FocusEvent) {
@@ -283,18 +264,7 @@ export class MediaPreview extends LitElement {
   /** Toggles playback for playable types; a no-op reveal for images. */
   private _commit() {
     if (!this.previewSrc || !this._isPlayable) return;
-
-    const preview = SharedMediaPreview.getInstance();
-    this._playing = preview.togglePlay({
-      src: this.previewSrc,
-      type: this.previewType,
-      kind: this.mediaKind ?? undefined,
-      triggerRect: this.getBoundingClientRect(),
-      // Anchor the grown bubble beside the card rather than over its text.
-      placement: this.previewPosition === 'cursor' ? 'right' : this.previewPosition,
-      // Touch: lets the bubble follow this card as the page scrolls.
-      getRect: () => this.getBoundingClientRect(),
-    });
+    this._playing = SharedMediaPreview.getInstance().commit(this._trigger);
   }
 
   private _handleClick() {
@@ -322,20 +292,8 @@ export class MediaPreview extends LitElement {
   /** Reveals this card's glimpse. Called only by the shared coordinator. */
   revealFromScroll(): void {
     if (!this.previewSrc) return;
-
-    const rect = this.getBoundingClientRect();
-    SharedMediaPreview.getInstance().show({
-      src: this.previewSrc,
-      type: this.previewType,
-      kind: this.mediaKind ?? undefined,
-      x: rect.left + rect.width / 2,
-      y: rect.top + rect.height / 2,
-      placement: this.previewPosition === 'cursor' ? 'right' : this.previewPosition,
-      triggerRect: rect,
-      immediate: true,
-      // Keep the glimpse glued to this card as the page scrolls.
-      getRect: () => this.getBoundingClientRect(),
-    });
+    // Touch has no cursor: anchor the glimpse beside the card, glued on scroll.
+    SharedMediaPreview.getInstance().reveal(this._trigger, { immediate: true, anchor: true });
   }
 
   // --- Render ---

--- a/v2-blog/tests/unit/components/media-preview.test.ts
+++ b/v2-blog/tests/unit/components/media-preview.test.ts
@@ -1,10 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const previewApi = {
-  show: vi.fn(),
+  reveal: vi.fn(),
   move: vi.fn(),
   hide: vi.fn(),
-  togglePlay: vi.fn(() => true),
+  commit: vi.fn(() => true),
   stop: vi.fn(),
 };
 
@@ -19,15 +19,15 @@ import { MediaPreview } from "../../../src/components/media-preview.ts";
 
 describe("media-preview", () => {
   beforeEach(() => {
-    previewApi.show.mockReset();
+    previewApi.reveal.mockReset();
     previewApi.move.mockReset();
     previewApi.hide.mockReset();
-    previewApi.togglePlay.mockReset();
-    previewApi.togglePlay.mockReturnValue(true);
+    previewApi.commit.mockReset();
+    previewApi.commit.mockReturnValue(true);
     previewApi.stop.mockReset();
   });
 
-  it("delegates mouseenter to the shared preview with component positioning", async () => {
+  it("reveals on mouseenter, handing over a trigger + the cursor point", async () => {
     const element = new MediaPreview();
     element.previewSrc = "/assets/example.webp";
     element.previewType = "image";
@@ -41,17 +41,18 @@ describe("media-preview", () => {
     const wrapper = element.shadowRoot?.querySelector(".wrapper");
     wrapper?.dispatchEvent(new MouseEvent("mouseenter", { clientX: 15, clientY: 25, bubbles: true }));
 
-    expect(previewApi.show).toHaveBeenCalledWith({
-      src: "/assets/example.webp",
-      type: "image",
-      x: 15,
-      y: 25,
-      placement: "right",
-      triggerRect: expect.any(DOMRect),
-    });
+    expect(previewApi.reveal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        src: "/assets/example.webp",
+        type: "image",
+        placement: "right",
+        getRect: expect.any(Function),
+      }),
+      { cursor: { x: 15, y: 25 } }
+    );
   });
 
-  it("passes the media kind through to the shared preview", async () => {
+  it("passes the media kind through on the trigger", async () => {
     const element = new MediaPreview();
     element.previewSrc = "/assets/cover.jpg";
     element.previewType = "image";
@@ -65,8 +66,9 @@ describe("media-preview", () => {
     const wrapper = element.shadowRoot?.querySelector(".wrapper");
     wrapper?.dispatchEvent(new MouseEvent("mouseenter", { clientX: 5, clientY: 5, bubbles: true }));
 
-    expect(previewApi.show).toHaveBeenCalledWith(
-      expect.objectContaining({ kind: "album" })
+    expect(previewApi.reveal).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "album" }),
+      expect.anything()
     );
   });
 
@@ -80,7 +82,7 @@ describe("media-preview", () => {
     expect(element.mediaKind).toBe("album");
   });
 
-  it("does not call show when previewSrc is missing", async () => {
+  it("does not touch the bubble when previewSrc is missing", async () => {
     const element = new MediaPreview();
     document.body.appendChild(element);
     await element.updateComplete;
@@ -89,11 +91,11 @@ describe("media-preview", () => {
     wrapper?.dispatchEvent(new MouseEvent("mouseenter", { clientX: 10, clientY: 20, bubbles: true }));
     wrapper?.dispatchEvent(new MouseEvent("mousemove", { clientX: 30, clientY: 40, bubbles: true }));
 
-    expect(previewApi.show).not.toHaveBeenCalled();
+    expect(previewApi.reveal).not.toHaveBeenCalled();
     expect(previewApi.move).not.toHaveBeenCalled();
   });
 
-  it("shows the preview on keyboard focus when the content has meaning", async () => {
+  it("reveals immediately on keyboard focus (no cursor)", async () => {
     const element = new MediaPreview();
     element.previewSrc = "/assets/example.webp";
     element.previewType = "image";
@@ -109,15 +111,10 @@ describe("media-preview", () => {
 
     wrapper?.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
 
-    expect(previewApi.show).toHaveBeenCalledWith({
-      src: "/assets/example.webp",
-      type: "image",
-      x: 40,
-      y: 55,
-      placement: "bottom",
-      triggerRect: expect.any(DOMRect),
-      immediate: true,
-    });
+    expect(previewApi.reveal).toHaveBeenCalledWith(
+      expect.objectContaining({ src: "/assets/example.webp", placement: "bottom", getRect: expect.any(Function) }),
+      { immediate: true }
+    );
   });
 
   it("hides the preview when focus leaves the component", async () => {
@@ -133,7 +130,7 @@ describe("media-preview", () => {
     expect(previewApi.hide).toHaveBeenCalledTimes(1);
   });
 
-  it("delegates mousemove and mouseleave to the shared preview", async () => {
+  it("repositions on mousemove and hides on mouseleave", async () => {
     const element = new MediaPreview();
     element.previewSrc = "/assets/example.webp";
 
@@ -146,12 +143,10 @@ describe("media-preview", () => {
     wrapper?.dispatchEvent(new MouseEvent("mousemove", { clientX: 50, clientY: 60, bubbles: true }));
     wrapper?.dispatchEvent(new MouseEvent("mouseleave", { bubbles: true }));
 
-    expect(previewApi.move).toHaveBeenCalledWith({
-      x: 50,
-      y: 60,
-      placement: "cursor",
-      triggerRect: expect.any(DOMRect),
-    });
+    expect(previewApi.move).toHaveBeenCalledWith(
+      expect.objectContaining({ getRect: expect.any(Function) }),
+      { x: 50, y: 60 }
+    );
     expect(previewApi.hide).toHaveBeenCalledTimes(1);
   });
 
@@ -173,7 +168,7 @@ describe("media-preview", () => {
 
     wrapper?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
 
-    expect(previewApi.togglePlay).toHaveBeenCalledWith(
+    expect(previewApi.commit).toHaveBeenCalledWith(
       expect.objectContaining({ src: "/assets/song.mp3", type: "audio", kind: "album" })
     );
 
@@ -194,7 +189,7 @@ describe("media-preview", () => {
     const wrapper = element.shadowRoot?.querySelector(".wrapper");
 
     wrapper?.dispatchEvent(new KeyboardEvent("keydown", { key: " ", bubbles: true }));
-    expect(previewApi.togglePlay).toHaveBeenCalledTimes(1);
+    expect(previewApi.commit).toHaveBeenCalledTimes(1);
 
     await element.updateComplete;
     wrapper?.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
@@ -222,7 +217,7 @@ describe("media-preview", () => {
     expect(wrapper?.getAttribute("aria-pressed")).toBe("false");
   });
 
-  it("is reveal-only for images — no button role, no playback on click", async () => {
+  it("is reveal-only for images — no button role, no commit on click", async () => {
     const element = new MediaPreview();
     element.previewSrc = "/assets/cover.jpg";
     element.previewType = "image";
@@ -235,6 +230,6 @@ describe("media-preview", () => {
     expect(wrapper?.getAttribute("aria-pressed")).toBeNull();
 
     wrapper?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    expect(previewApi.togglePlay).not.toHaveBeenCalled();
+    expect(previewApi.commit).not.toHaveBeenCalled();
   });
 });

--- a/v2-blog/tests/unit/helpers/previewChannels.test.ts
+++ b/v2-blog/tests/unit/helpers/previewChannels.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  AudioChannel,
+  ImageChannel,
+  VideoChannel,
+  createMediaChannels,
+} from "../../../src/_helpers/previewChannels.ts";
+
+describe("previewChannels", () => {
+  it("builds one channel per type, each with its element", () => {
+    const channels = createMediaChannels();
+    expect(channels.image).toBeInstanceOf(ImageChannel);
+    expect(channels.video).toBeInstanceOf(VideoChannel);
+    expect(channels.audio).toBeInstanceOf(AudioChannel);
+    expect(channels.image.el.tagName).toBe("IMG");
+    expect(channels.video.el.tagName).toBe("VIDEO");
+    expect(channels.audio.el.tagName).toBe("AUDIO");
+  });
+
+  describe("ImageChannel", () => {
+    it("loads a src blurred, clears the blur on decode, activates/deactivates", () => {
+      const ch = new ImageChannel();
+
+      ch.load("/assets/a.webp");
+      expect(ch.el.classList.contains("is-loaded")).toBe(false);
+
+      ch.el.dispatchEvent(new Event("load"));
+      expect(ch.el.classList.contains("is-loaded")).toBe(true);
+
+      ch.activate();
+      expect(ch.el.classList.contains("visible")).toBe(true);
+      ch.deactivate();
+      expect(ch.el.classList.contains("visible")).toBe(false);
+    });
+
+    it("clears the blur on error so a failed load never stays frosted", () => {
+      const ch = new ImageChannel();
+      ch.load("/assets/broken.webp");
+      ch.el.dispatchEvent(new Event("error"));
+      expect(ch.el.classList.contains("is-loaded")).toBe(true);
+    });
+
+    it("has no-op play/pause (images are reveal-only)", () => {
+      const ch = new ImageChannel();
+      expect(() => ch.play()).not.toThrow();
+      expect(() => ch.pause()).not.toThrow();
+      expect(ch.play()).toBeUndefined();
+    });
+  });
+
+  describe("VideoChannel", () => {
+    it("re-blurs on src change and clears on canplay", () => {
+      const ch = new VideoChannel();
+      ch.el.classList.add("is-loaded");
+
+      ch.load("/assets/a.mp4");
+      expect(ch.el.classList.contains("is-loaded")).toBe(false);
+
+      ch.el.dispatchEvent(new Event("canplay"));
+      expect(ch.el.classList.contains("is-loaded")).toBe(true);
+    });
+
+    it("delegates play and guards pause on the paused flag", () => {
+      const ch = new VideoChannel();
+      const play = vi.fn().mockResolvedValue(undefined);
+      const pause = vi.fn();
+      Object.defineProperty(ch.el, "play", { configurable: true, value: play });
+      Object.defineProperty(ch.el, "pause", { configurable: true, value: pause });
+
+      Object.defineProperty(ch.el, "paused", { configurable: true, get: () => false });
+      ch.play();
+      ch.pause();
+      expect(play).toHaveBeenCalledTimes(1);
+      expect(pause).toHaveBeenCalledTimes(1);
+
+      // Already paused → pause() is a no-op, no redundant call.
+      Object.defineProperty(ch.el, "paused", { configurable: true, get: () => true });
+      ch.pause();
+      expect(pause).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("AudioChannel", () => {
+    it("has no visual: activate/deactivate never touch the visible class", () => {
+      const ch = new AudioChannel();
+      ch.activate();
+      expect(ch.el.classList.contains("visible")).toBe(false);
+      ch.deactivate();
+      expect(ch.el.classList.contains("visible")).toBe(false);
+    });
+
+    it("delegates play and guards pause", () => {
+      const ch = new AudioChannel();
+      const play = vi.fn().mockResolvedValue(undefined);
+      const pause = vi.fn();
+      Object.defineProperty(ch.el, "play", { configurable: true, value: play });
+      Object.defineProperty(ch.el, "pause", { configurable: true, value: pause });
+      Object.defineProperty(ch.el, "paused", { configurable: true, get: () => false });
+
+      ch.play();
+      ch.pause();
+      expect(play).toHaveBeenCalledTimes(1);
+      expect(pause).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/v2-blog/tests/unit/helpers/previewGeometry.test.ts
+++ b/v2-blog/tests/unit/helpers/previewGeometry.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import {
+  PREVIEW_OFFSET,
+  computePreviewPosition,
+  type PositionInput,
+} from "../../../src/_helpers/previewGeometry.ts";
+
+/** A large viewport so nothing clamps unless the test wants it to. */
+const VIEWPORT = { width: 1000, height: 800 };
+const SIZE = { w: 100, h: 100 };
+
+function pos(overrides: Partial<PositionInput> = {}) {
+  return computePreviewPosition({
+    placement: "cursor",
+    triggerRect: null,
+    cursor: { x: 0, y: 0 },
+    size: SIZE,
+    viewport: VIEWPORT,
+    ...overrides,
+  });
+}
+
+/** Minimal DOMRect-shaped stub — the geometry only reads the box fields. */
+function rect(left: number, top: number, width: number, height: number): DOMRect {
+  return {
+    left,
+    top,
+    width,
+    height,
+    right: left + width,
+    bottom: top + height,
+    x: left,
+    y: top,
+    toJSON: () => ({}),
+  } as DOMRect;
+}
+
+describe("computePreviewPosition", () => {
+  it("centers on the cursor for cursor placement", () => {
+    expect(pos({ placement: "cursor", cursor: { x: 400, y: 300 } })).toEqual({
+      x: 400 - SIZE.w / 2,
+      y: 300 - SIZE.h / 2,
+    });
+  });
+
+  it("anchors to the right of the trigger rect, vertically centered", () => {
+    const r = rect(200, 300, 60, 40);
+    expect(pos({ placement: "right", triggerRect: r })).toEqual({
+      x: r.right + PREVIEW_OFFSET,
+      y: r.top + (r.height - SIZE.h) / 2,
+    });
+  });
+
+  it("anchors to the left of the trigger rect", () => {
+    const r = rect(400, 300, 60, 40);
+    expect(pos({ placement: "left", triggerRect: r })).toEqual({
+      x: r.left - SIZE.w - PREVIEW_OFFSET,
+      y: r.top + (r.height - SIZE.h) / 2,
+    });
+  });
+
+  it("anchors above the trigger rect, horizontally centered", () => {
+    const r = rect(400, 300, 60, 40);
+    expect(pos({ placement: "top", triggerRect: r })).toEqual({
+      x: r.left + (r.width - SIZE.w) / 2,
+      y: r.top - SIZE.h - PREVIEW_OFFSET,
+    });
+  });
+
+  it("anchors below the trigger rect", () => {
+    const r = rect(400, 300, 60, 40);
+    expect(pos({ placement: "bottom", triggerRect: r })).toEqual({
+      x: r.left + (r.width - SIZE.w) / 2,
+      y: r.bottom + PREVIEW_OFFSET,
+    });
+  });
+
+  it("clamps horizontally at the right edge", () => {
+    // Right-anchor a rect flush against the viewport's right side.
+    const r = rect(980, 300, 20, 40);
+    const { x } = pos({ placement: "right", triggerRect: r });
+    expect(x).toBe(VIEWPORT.width - SIZE.w - PREVIEW_OFFSET);
+  });
+
+  it("clamps horizontally at the left edge", () => {
+    const { x } = pos({ placement: "cursor", cursor: { x: -50, y: 300 } });
+    expect(x).toBe(PREVIEW_OFFSET);
+  });
+
+  it("clamps vertically by default", () => {
+    const { y } = pos({ placement: "cursor", cursor: { x: 400, y: 5000 } });
+    expect(y).toBe(VIEWPORT.height - SIZE.h - PREVIEW_OFFSET);
+  });
+
+  it("does NOT clamp vertically when unclampY is set (trailing off-screen)", () => {
+    // A rect scrolled far below the viewport should trail off, not pin to the edge.
+    const r = rect(400, 5000, 60, 40);
+    const { y } = pos({ placement: "right", triggerRect: r, unclampY: true });
+    expect(y).toBe(r.top + (r.height - SIZE.h) / 2); // 5000 - 30 = 4970, un-clamped
+    expect(y).toBeGreaterThan(VIEWPORT.height);
+  });
+
+  it("centers in the viewport for an anchored placement with no rect (commit fallback)", () => {
+    // Unclamped, ignores the cursor — matches the old _positionAnchored fallback.
+    expect(pos({ placement: "right", triggerRect: null, cursor: { x: 999, y: 999 } })).toEqual({
+      x: (VIEWPORT.width - SIZE.w) / 2,
+      y: (VIEWPORT.height - SIZE.h) / 2,
+    });
+  });
+
+  it("centers on the cursor for cursor placement with no rect", () => {
+    expect(pos({ placement: "cursor", triggerRect: null, cursor: { x: 300, y: 200 } })).toEqual({
+      x: 300 - SIZE.w / 2,
+      y: 200 - SIZE.h / 2,
+    });
+  });
+});

--- a/v2-blog/tests/unit/helpers/scrollAnchor.test.ts
+++ b/v2-blog/tests/unit/helpers/scrollAnchor.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ScrollAnchor } from "../../../src/_helpers/scrollAnchor.ts";
+
+/** A manual animation-frame queue so we control exactly when frames flush. */
+let rafCbs: Array<FrameRequestCallback | undefined>;
+
+function flushRaf() {
+  const cbs = rafCbs;
+  rafCbs = [];
+  cbs.forEach((cb) => cb?.(0));
+}
+
+beforeEach(() => {
+  rafCbs = [];
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => rafCbs.push(cb));
+  vi.stubGlobal("cancelAnimationFrame", (id: number) => {
+    rafCbs[id - 1] = undefined;
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("ScrollAnchor", () => {
+  it("rAF-throttles multiple scrolls in one frame into a single onScrollFrame", () => {
+    const onScrollFrame = vi.fn();
+    const anchor = new ScrollAnchor({ onScrollFrame, onResize: vi.fn() });
+    anchor.start();
+
+    window.dispatchEvent(new Event("scroll"));
+    window.dispatchEvent(new Event("scroll"));
+    window.dispatchEvent(new Event("scroll"));
+    // Nothing fires until the frame flushes.
+    expect(onScrollFrame).not.toHaveBeenCalled();
+
+    flushRaf();
+    expect(onScrollFrame).toHaveBeenCalledTimes(1);
+
+    // A fresh scroll after the frame schedules the next one.
+    window.dispatchEvent(new Event("scroll"));
+    flushRaf();
+    expect(onScrollFrame).toHaveBeenCalledTimes(2);
+  });
+
+  it("forwards resize immediately, un-throttled", () => {
+    const onResize = vi.fn();
+    const anchor = new ScrollAnchor({ onScrollFrame: vi.fn(), onResize });
+    anchor.start();
+
+    window.dispatchEvent(new Event("resize"));
+    window.dispatchEvent(new Event("resize"));
+    expect(onResize).toHaveBeenCalledTimes(2);
+  });
+
+  it("detaches on stop and cancels the pending frame", () => {
+    const onScrollFrame = vi.fn();
+    const anchor = new ScrollAnchor({ onScrollFrame, onResize: vi.fn() });
+    anchor.start();
+
+    // Queue a frame, then stop before it flushes.
+    window.dispatchEvent(new Event("scroll"));
+    anchor.stop();
+    flushRaf();
+    expect(onScrollFrame).not.toHaveBeenCalled();
+
+    // Further events after stop are ignored.
+    window.dispatchEvent(new Event("scroll"));
+    flushRaf();
+    expect(onScrollFrame).not.toHaveBeenCalled();
+  });
+
+  it("is idempotent: a second start does not double-subscribe", () => {
+    const onScrollFrame = vi.fn();
+    const anchor = new ScrollAnchor({ onScrollFrame, onResize: vi.fn() });
+    anchor.start();
+    anchor.start();
+
+    window.dispatchEvent(new Event("scroll"));
+    flushRaf();
+    expect(onScrollFrame).toHaveBeenCalledTimes(1);
+  });
+
+  it("can restart after stop", () => {
+    const onScrollFrame = vi.fn();
+    const anchor = new ScrollAnchor({ onScrollFrame, onResize: vi.fn() });
+
+    anchor.start();
+    anchor.stop();
+    anchor.start();
+
+    window.dispatchEvent(new Event("scroll"));
+    flushRaf();
+    expect(onScrollFrame).toHaveBeenCalledTimes(1);
+  });
+});

--- a/v2-blog/tests/unit/helpers/sharedPreview-body.test.ts
+++ b/v2-blog/tests/unit/helpers/sharedPreview-body.test.ts
@@ -24,11 +24,10 @@ describe("sharedPreview body attachment", () => {
       get: () => originalBody,
     });
 
-    preview.show({
-      src: "/assets/example.webp",
-      x: 20,
-      y: 30,
-    });
+    preview.reveal(
+      { src: "/assets/example.webp", placement: "cursor", getRect: () => new DOMRect(0, 0, 40, 40) },
+      { cursor: { x: 20, y: 30 } }
+    );
 
     expect(document.querySelectorAll("#mediaPreview")).toHaveLength(1);
   });

--- a/v2-blog/tests/unit/helpers/sharedPreview.test.ts
+++ b/v2-blog/tests/unit/helpers/sharedPreview.test.ts
@@ -1,4 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PreviewTrigger } from "../../../src/_helpers/sharedPreview.ts";
+
+/** Builds a trigger descriptor; override placement/getRect/type/kind per test. */
+function trigger(src: string, over: Partial<PreviewTrigger> = {}): PreviewTrigger {
+  return {
+    src,
+    placement: "cursor",
+    getRect: () => new DOMRect(0, 0, 40, 40),
+    ...over,
+  };
+}
 
 describe("sharedPreview", () => {
   beforeEach(() => {
@@ -16,7 +27,7 @@ describe("sharedPreview", () => {
     const preview = SharedMediaPreview.getInstance();
     const wrapper = document.querySelector<HTMLDivElement>("#mediaPreview");
 
-    preview.show({ src: "/assets/cover.webp", x: 100, y: 100 });
+    preview.reveal(trigger("/assets/cover.webp"), { cursor: { x: 100, y: 100 } });
 
     // A sweep-through hover must not flash the bubble.
     expect(wrapper?.classList.contains("is-visible")).toBe(false);
@@ -30,12 +41,13 @@ describe("sharedPreview", () => {
     const { SharedMediaPreview } = await import("../../../src/_helpers/sharedPreview.ts");
     const preview = SharedMediaPreview.getInstance();
     const wrapper = document.querySelector<HTMLDivElement>("#mediaPreview");
+    const t = trigger("/assets/cover.webp");
 
-    preview.show({ src: "/assets/cover.webp", x: 0, y: 0 });
+    preview.reveal(t, { cursor: { x: 0, y: 0 } });
 
     // Cursor keeps travelling fast (50px per 100ms tick) — no intent.
     for (let i = 1; i <= 5; i++) {
-      preview.move({ x: i * 50, y: 0 });
+      preview.move(t, { x: i * 50, y: 0 });
       vi.advanceTimersByTime(100);
     }
     expect(wrapper?.classList.contains("is-visible")).toBe(false);
@@ -50,7 +62,7 @@ describe("sharedPreview", () => {
     const preview = SharedMediaPreview.getInstance();
     const wrapper = document.querySelector<HTMLDivElement>("#mediaPreview");
 
-    preview.show({ src: "/assets/cover.webp", x: 100, y: 100, immediate: true });
+    preview.reveal(trigger("/assets/cover.webp"), { cursor: { x: 100, y: 100 }, immediate: true });
 
     expect(wrapper?.classList.contains("is-visible")).toBe(true);
   });
@@ -62,7 +74,7 @@ describe("sharedPreview", () => {
     const image = wrapper?.querySelector("img");
 
     // Intent proven on item A.
-    preview.show({ src: "/assets/a.webp", x: 100, y: 100 });
+    preview.reveal(trigger("/assets/a.webp"), { cursor: { x: 100, y: 100 } });
     vi.advanceTimersByTime(100);
     expect(wrapper?.classList.contains("is-visible")).toBe(true);
 
@@ -71,7 +83,7 @@ describe("sharedPreview", () => {
     expect(wrapper?.classList.contains("is-visible")).toBe(true);
 
     // …and the sibling swaps in with no re-proving of intent.
-    preview.show({ src: "/assets/b.webp", x: 120, y: 100 });
+    preview.reveal(trigger("/assets/b.webp"), { cursor: { x: 120, y: 100 } });
     expect(wrapper?.classList.contains("is-visible")).toBe(true);
     expect(image?.getAttribute("src")).toContain("/assets/b.webp");
 
@@ -86,7 +98,7 @@ describe("sharedPreview", () => {
     const preview = SharedMediaPreview.getInstance();
     const wrapper = document.querySelector<HTMLDivElement>("#mediaPreview");
 
-    preview.show({ src: "/assets/cover.webp", x: 100, y: 100 });
+    preview.reveal(trigger("/assets/cover.webp"), { cursor: { x: 100, y: 100 } });
     preview.hide();
 
     vi.advanceTimersByTime(1000);
@@ -99,7 +111,7 @@ describe("sharedPreview", () => {
     const wrapper = document.querySelector<HTMLDivElement>("#mediaPreview");
     const image = wrapper?.querySelector("img");
 
-    preview.show({ src: "/assets/a.webp", x: 100, y: 100, immediate: true });
+    preview.reveal(trigger("/assets/a.webp"), { cursor: { x: 100, y: 100 }, immediate: true });
 
     // Fresh media: still loading → CSS keeps it blurred.
     expect(image?.classList.contains("is-loaded")).toBe(false);
@@ -108,7 +120,7 @@ describe("sharedPreview", () => {
     expect(image?.classList.contains("is-loaded")).toBe(true);
 
     // Swapping to different media starts blurred again.
-    preview.show({ src: "/assets/b.webp", x: 100, y: 100, immediate: true });
+    preview.reveal(trigger("/assets/b.webp"), { cursor: { x: 100, y: 100 }, immediate: true });
     expect(image?.classList.contains("is-loaded")).toBe(false);
   });
 
@@ -123,13 +135,13 @@ describe("sharedPreview", () => {
       value: vi.fn().mockResolvedValue(undefined),
     });
 
-    preview.show({ src: "/assets/a.mp4", x: 100, y: 100, type: "video", immediate: true });
+    preview.reveal(trigger("/assets/a.mp4", { type: "video" }), { cursor: { x: 100, y: 100 }, immediate: true });
     expect(video?.classList.contains("is-loaded")).toBe(false);
 
     video?.dispatchEvent(new Event("canplay"));
     expect(video?.classList.contains("is-loaded")).toBe(true);
 
-    preview.show({ src: "/assets/b.mp4", x: 100, y: 100, type: "video", immediate: true });
+    preview.reveal(trigger("/assets/b.mp4", { type: "video" }), { cursor: { x: 100, y: 100 }, immediate: true });
     expect(video?.classList.contains("is-loaded")).toBe(false);
   });
 
@@ -157,11 +169,7 @@ describe("sharedPreview", () => {
     const { SharedMediaPreview } = await import("../../../src/_helpers/sharedPreview.ts");
     const preview = SharedMediaPreview.getInstance();
 
-    preview.show({
-      src: "/assets/example.webp",
-      x: -30,
-      y: -10,
-    });
+    preview.reveal(trigger("/assets/example.webp"), { cursor: { x: -30, y: -10 } });
     vi.advanceTimersByTime(100);
 
     const wrapper = document.querySelector<HTMLDivElement>("#mediaPreview");
@@ -189,18 +197,14 @@ describe("sharedPreview", () => {
     Object.defineProperty(video!, "paused", { configurable: true, get: () => false });
 
     // Reveal shows the clip paused — reveal ≠ play (ADR 0004).
-    preview.show({ src: "/assets/demo.mp4", x: 40, y: 50, type: "video" });
+    preview.reveal(trigger("/assets/demo.mp4", { type: "video" }), { cursor: { x: 40, y: 50 } });
     vi.advanceTimersByTime(100);
 
     expect(video?.classList.contains("visible")).toBe(true);
     expect(play).not.toHaveBeenCalled();
 
     // Commit: playback starts, the bubble grows and anchors.
-    preview.togglePlay({
-      src: "/assets/demo.mp4",
-      type: "video",
-      triggerRect: new DOMRect(0, 0, 40, 40),
-    });
+    preview.commit(trigger("/assets/demo.mp4", { type: "video", getRect: () => new DOMRect(0, 0, 40, 40) }));
 
     expect(play).toHaveBeenCalledTimes(1);
     expect(wrapper?.classList.contains("is-playing")).toBe(true);
@@ -226,14 +230,14 @@ describe("sharedPreview", () => {
     Object.defineProperty(video!, "pause", { configurable: true, value: pause });
     Object.defineProperty(video!, "paused", { configurable: true, get: () => false });
 
-    const rect = new DOMRect(0, 0, 40, 40);
+    const t = trigger("/assets/demo.mp4", { type: "video", getRect: () => new DOMRect(0, 0, 40, 40) });
 
-    const first = preview.togglePlay({ src: "/assets/demo.mp4", type: "video", triggerRect: rect });
+    const first = preview.commit(t);
     expect(first).toBe(true);
     expect(play).toHaveBeenCalledTimes(1);
     expect(wrapper?.classList.contains("is-playing")).toBe(true);
 
-    const second = preview.togglePlay({ src: "/assets/demo.mp4", type: "video", triggerRect: rect });
+    const second = preview.commit(t);
     expect(second).toBe(false);
     expect(pause).toHaveBeenCalled();
     expect(wrapper?.classList.contains("is-playing")).toBe(false);
@@ -251,12 +255,9 @@ describe("sharedPreview", () => {
     Object.defineProperty(audio!, "pause", { configurable: true, value: pause });
     Object.defineProperty(audio!, "paused", { configurable: true, get: () => false });
 
-    const playing = preview.togglePlay({
-      src: "/assets/song.mp3",
-      type: "audio",
-      kind: "album",
-      triggerRect: new DOMRect(0, 0, 40, 40),
-    });
+    const playing = preview.commit(
+      trigger("/assets/song.mp3", { type: "audio", kind: "album", getRect: () => new DOMRect(0, 0, 40, 40) })
+    );
 
     expect(playing).toBe(true);
     expect(play).toHaveBeenCalledTimes(1);
@@ -283,7 +284,7 @@ describe("sharedPreview", () => {
       value: vi.fn().mockRejectedValue(blockedError),
     });
 
-    preview.togglePlay({ src: "/assets/demo.mp4", type: "video", triggerRect: new DOMRect(0, 0, 40, 40) });
+    preview.commit(trigger("/assets/demo.mp4", { type: "video", getRect: () => new DOMRect(0, 0, 40, 40) }));
 
     await Promise.resolve();
 
@@ -306,19 +307,19 @@ describe("sharedPreview", () => {
     Object.defineProperty(video!, "paused", { configurable: true, get: () => false });
 
     // Image glimpse: small circle.
-    preview.show({ src: "/assets/example.webp", x: 200, y: 200 });
+    preview.reveal(trigger("/assets/example.webp"), { cursor: { x: 200, y: 200 } });
     expect(wrapper?.style.getPropertyValue("--preview-w")).toBe("100px");
     expect(wrapper?.style.getPropertyValue("--preview-h")).toBe("100px");
     expect(wrapper?.dataset.type).toBe("image");
 
     // Video glimpse is the SAME small circle — no more 16:9 rect.
-    preview.show({ src: "/assets/demo.mp4", x: 400, y: 300, type: "video" });
+    preview.reveal(trigger("/assets/demo.mp4", { type: "video" }), { cursor: { x: 400, y: 300 } });
     expect(wrapper?.style.getPropertyValue("--preview-w")).toBe("100px");
     expect(wrapper?.style.getPropertyValue("--preview-h")).toBe("100px");
     expect(wrapper?.dataset.type).toBe("video");
 
     // Committing grows it.
-    preview.togglePlay({ src: "/assets/demo.mp4", type: "video", triggerRect: new DOMRect(0, 0, 40, 40) });
+    preview.commit(trigger("/assets/demo.mp4", { type: "video", getRect: () => new DOMRect(0, 0, 40, 40) }));
     expect(wrapper?.style.getPropertyValue("--preview-w")).toBe("220px");
     expect(wrapper?.style.getPropertyValue("--preview-h")).toBe("220px");
   });
@@ -328,15 +329,15 @@ describe("sharedPreview", () => {
     const preview = SharedMediaPreview.getInstance();
     const wrapper = document.querySelector<HTMLDivElement>("#mediaPreview");
 
-    preview.show({ src: "/assets/cover.jpg", x: 200, y: 200, kind: "album" });
+    preview.reveal(trigger("/assets/cover.jpg", { kind: "album" }), { cursor: { x: 200, y: 200 } });
     expect(wrapper?.dataset.kind).toBe("album");
 
     preview.hide();
     expect(wrapper?.dataset.kind).toBeUndefined();
 
-    // a kindless show never leaks the previous kind
-    preview.show({ src: "/assets/cover.jpg", x: 200, y: 200, kind: "album" });
-    preview.show({ src: "/assets/other.jpg", x: 200, y: 200 });
+    // a kindless reveal never leaks the previous kind
+    preview.reveal(trigger("/assets/cover.jpg", { kind: "album" }), { cursor: { x: 200, y: 200 } });
+    preview.reveal(trigger("/assets/other.jpg"), { cursor: { x: 200, y: 200 } });
     expect(wrapper?.dataset.kind).toBeUndefined();
   });
 
@@ -345,7 +346,7 @@ describe("sharedPreview", () => {
     const preview = SharedMediaPreview.getInstance();
     const wrapper = document.querySelector<HTMLDivElement>("#mediaPreview");
 
-    preview.show({ src: "/assets/b.webp", x: 100, y: 100, immediate: true });
+    preview.reveal(trigger("/assets/b.webp"), { cursor: { x: 100, y: 100 }, immediate: true });
     expect(wrapper?.classList.contains("is-visible")).toBe(true);
 
     // A card that no longer owns the bubble must not hide it.
@@ -370,13 +371,9 @@ describe("sharedPreview", () => {
     const { SharedMediaPreview } = await import("../../../src/_helpers/sharedPreview.ts");
     const preview = SharedMediaPreview.getInstance();
 
-    preview.show({
-      src: "/assets/example.jpg",
-      x: 0,
-      y: 0,
-      placement: "right",
-      triggerRect: new DOMRect(20, 50, 40, 40),
-    });
+    preview.reveal(
+      trigger("/assets/example.jpg", { placement: "right", getRect: () => new DOMRect(20, 50, 40, 40) })
+    );
 
     const wrapper = document.querySelector<HTMLDivElement>("#mediaPreview");
 
@@ -396,7 +393,7 @@ describe("sharedPreview", () => {
     Object.defineProperty(video!, "paused", { configurable: true, get: () => false });
 
     // matchMedia undefined here → coarse pointer false → desktop path.
-    preview.togglePlay({ src: "/assets/demo.mp4", type: "video", triggerRect: new DOMRect(0, 100, 40, 40) });
+    preview.commit(trigger("/assets/demo.mp4", { type: "video", getRect: () => new DOMRect(0, 100, 40, 40) }));
     expect(wrapper?.classList.contains("is-playing")).toBe(true);
 
     // A tiny jitter must not dismiss.
@@ -430,7 +427,7 @@ describe("sharedPreview", () => {
       Object.defineProperty(audio!, "paused", { configurable: true, get: () => false });
 
       let rect = new DOMRect(0, 300, 300, 80); // on-screen
-      preview.togglePlay({ src: "/assets/song.mp3", type: "audio", kind: "album", getRect: () => rect });
+      preview.commit(trigger("/assets/song.mp3", { type: "audio", kind: "album", getRect: () => rect }));
       expect(preview.isPlaying()).toBe(true);
 
       // Still partly visible → keeps playing.
@@ -458,14 +455,10 @@ describe("sharedPreview", () => {
       const wrapper = document.querySelector<HTMLDivElement>("#mediaPreview");
 
       let rect = new DOMRect(0, 400, 300, 40);
-      preview.show({
-        src: "/assets/cover.jpg",
-        x: 0, y: 0,
-        placement: "right",
-        triggerRect: rect,
-        immediate: true,
-        getRect: () => rect,
-      });
+      preview.reveal(
+        trigger("/assets/cover.jpg", { placement: "right", getRect: () => rect }),
+        { immediate: true }
+      );
       expect(wrapper?.classList.contains("is-visible")).toBe(true);
 
       // Card scrolled above the viewport: y follows it negative, not pinned.


### PR DESCRIPTION
Architectural deepening of the home-page media-preview, per ADR 0004. Four behaviour-neutral refactors — each adds an internal seam so `SharedMediaPreview` becomes a thin coordinator over leaf modules that verify in isolation.

## Commits

| commit | deepening |
|---|---|
| `78a603f` | **pure geometry** — `previewGeometry.ts`, no window/DOM/singleton dependency; positioning becomes a testable pure function |
| `45ff402` | **PreviewTrigger adapter** — the singleton keys on a `PreviewTrigger` interface instead of reaching into the card |
| `d626d4c` | **ScrollAnchor** — policy-free scroll/resize listener lifecycle (attach/rAF-throttle/cancel) pulled out of the singleton |
| `a066745` | **MediaChannel adapters** — per-type `Image`/`Video`/`Audio` channels; the nine type-forks collapse to one `_active` invariant |

## Result

`SharedMediaPreview` no longer forks on media type, owns no raw listener bookkeeping, and computes no geometry inline — it coordinates three leaf modules.

Behaviour identical throughout. `npm run check` clean at every commit; unit count 184 → 208 (new suites for geometry, scroll anchor, channels).

Out of scope: report candidate #5 (single playing-truth source) — speculative, would touch ADR 0004; deferred.
