### PR TITLE
fix(theme): keep terminal overlay above the theme-swap view transition

### DIFF
--- a/v2-blog/src/_helpers/theme.ts
+++ b/v2-blog/src/_helpers/theme.ts
@@ -63,9 +63,6 @@ export function applyTheme(theme: Theme): void {
  *
  * @param theme - The theme to switch to.
  */
-/** Theme currently being applied by a running view transition, if any. */
-let pendingTheme: Theme | null = null;
-
 function applyThemeAnimated(theme: Theme): void {
   const root = document.documentElement;
 
@@ -73,9 +70,15 @@ function applyThemeAnimated(theme: Theme): void {
   // <theme-toggle> re-broadcasting through setTheme after the theme-change
   // event). Starting another view transition would skip the running one and
   // yank the .theme-vt class off mid-sweep, so bail before animating.
-  // `pendingTheme` is needed because applyTheme runs inside the async view
-  // transition callback, so dataset.theme is still stale when echoes arrive.
-  if (root.dataset.theme === theme || pendingTheme === theme) return;
+  // The pending flag lives on the DOM (not in a module variable) because
+  // esbuild bundles this helper separately into every component — the
+  // terminal-overlay and theme-toggle copies don't share module state, and a
+  // module-level guard lets the cross-bundle echo start a second transition
+  // that skips the first and strips .theme-vt mid-capture (the overlay
+  // z-index bug). A dataset flag is the same for every copy. It's also
+  // needed at all because applyTheme runs inside the async view transition
+  // callback, so dataset.theme is still stale when echoes arrive.
+  if (root.dataset.theme === theme || root.dataset.themePending === theme) return;
 
   const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 
@@ -84,15 +87,15 @@ function applyThemeAnimated(theme: Theme): void {
     return;
   }
 
-  pendingTheme = theme;
+  root.dataset.themePending = theme;
   root.classList.add("theme-vt");
 
   const transition = document.startViewTransition(() => applyTheme(theme));
   transition.finished.finally(() => {
     // Only clean up if a newer swap hasn't taken over (rapid re-toggle skips
     // this transition, and its own finally must not undo the newer one).
-    if (pendingTheme === theme) {
-      pendingTheme = null;
+    if (root.dataset.themePending === theme) {
+      delete root.dataset.themePending;
       root.classList.remove("theme-vt");
     }
   });

--- a/v2-blog/src/components/terminal-overlay.ts
+++ b/v2-blog/src/components/terminal-overlay.ts
@@ -56,8 +56,23 @@ export class TerminalOverlay extends LitElement {
     #overlay-dialog:not([open]) { display: none; }
     #overlay-dialog[open] { display: flex; flex-direction: column; }
 
+    /* The theme swap runs a view transition (see _helpers/theme.ts); its
+       ::view-transition overlay paints above the top layer, and top-layer
+       content is NOT part of the root snapshot — an unnamed open dialog gets
+       covered by the page sweep. Naming dialog + backdrop promotes them into
+       their own snapshot groups, which paint above the root group. Scoped to
+       [open] so a closed dialog never claims a name during page-nav
+       transitions. */
+    #overlay-dialog[open] {
+      view-transition-name: terminal-overlay;
+    }
+
     #overlay-dialog::backdrop {
       background: rgba(0, 0, 0, 0.55);
+    }
+
+    #overlay-dialog[open]::backdrop {
+      view-transition-name: terminal-overlay-backdrop;
     }
 
     @media (prefers-reduced-motion: no-preference) {

--- a/v2-blog/tests/unit/helpers/theme.test.ts
+++ b/v2-blog/tests/unit/helpers/theme.test.ts
@@ -21,13 +21,38 @@ function stubSystemDark(enabled: boolean) {
   });
 }
 
+/**
+ * Stubs document.startViewTransition with a controllable fake: the update
+ * callback runs asynchronously (like the real API, so dataset.theme is stale
+ * when same-tick echoes arrive) and `finished` resolves on demand.
+ */
+function stubViewTransition() {
+  let resolveFinished!: () => void;
+  const finished = new Promise<void>((r) => {
+    resolveFinished = r;
+  });
+  const start = vi.fn((cb: () => void) => {
+    const updateCallbackDone = Promise.resolve().then(() => cb());
+    return {
+      finished,
+      ready: updateCallbackDone,
+      updateCallbackDone,
+      skipTransition: vi.fn(),
+    };
+  });
+  document.startViewTransition = start as unknown as typeof document.startViewTransition;
+  return { start, resolveFinished };
+}
+
 beforeEach(() => {
   localStorage.clear();
   document.documentElement.removeAttribute("data-theme");
-  document.documentElement.classList.remove("dark");
+  document.documentElement.removeAttribute("data-theme-pending");
+  document.documentElement.classList.remove("dark", "theme-vt");
 });
 
 afterEach(() => {
+  delete (document as { startViewTransition?: unknown }).startViewTransition;
   vi.restoreAllMocks();
 });
 
@@ -73,5 +98,28 @@ describe("theme helper", () => {
     localStorage.setItem(THEME_STORAGE_KEY, "neon");
     stubSystemDark(false);
     expect(getTheme()).toBe("pinky");
+  });
+
+  it("starts a single view transition when an echo repeats the in-flight theme", async () => {
+    // The pending flag lives on the DOM because every component bundle gets
+    // its own copy of this module — the guard must hold even when the echo
+    // comes from another copy (terminal-overlay -> theme-change -> toggle).
+    stubSystemDark(false);
+    const { start, resolveFinished } = stubViewTransition();
+    const root = document.documentElement;
+
+    setTheme("dark");
+    setTheme("dark"); // echo while the transition is still pending
+
+    expect(start).toHaveBeenCalledTimes(1);
+    expect(root.dataset.themePending).toBe("dark");
+    expect(root.classList.contains("theme-vt")).toBe(true);
+
+    resolveFinished();
+    await vi.waitFor(() => {
+      expect(root.classList.contains("theme-vt")).toBe(false);
+    });
+    expect(root.dataset.themePending).toBeUndefined();
+    expect(root.dataset.theme).toBe("dark");
   });
 });


### PR DESCRIPTION
## Problem

Switching the theme through the terminal overlay (`theme` command) made the dialog and its backdrop drop behind the page content (titles, text, media previews) for the duration of the view-transition sweep, as if they had lost their z-index.

## Causes (two layers)

**1. The pending-theme echo guard didn't work across bundles.**
esbuild bundles `_helpers/theme.ts` separately into each component, so `theme-toggle.js` and `terminal-overlay.js` each carry their own copy of the module — and their own `pendingTheme` variable. When the terminal ran `setTheme`, the toggle echoed it back through the `theme-change` event from *its* copy, whose guard saw nothing pending, and started a second view transition. That skipped the first one, whose cleanup then stripped `.theme-vt` off the root mid-capture (~30ms in). With the class gone:
- `main` kept `view-transition-name: post`, so its snapshot painted **above** the dialog's group;
- the live-transition freeze rules and the root-crossfade kill were inactive.

The guard now lives on the DOM (`data-theme-pending` on the root element), which every bundle copy shares.

**2. Top-layer content is not part of the root snapshot.**
Even with a single clean transition, the `::view-transition` overlay paints above the top layer, and the unnamed open dialog was simply covered by the sweep. The open dialog and its backdrop now carry `view-transition-name`s (scoped to `[open]` so a closed dialog never claims a name during page-nav transitions), promoting them into their own snapshot groups that paint above the root sweep.

## Verification

- Reproduced and verified with the sweep slowed to 2.5s and frozen mid-flight via the Web Animations API: before the fix the headline/paragraph snapshots paint over the dialog; after, the dialog and backdrop stay on top while the page sweeps beneath them.
- Instrumented `classList` with stack traces to catch the cross-bundle double-transition (add from `terminal-overlay.js` at 233ms, add from `theme-toggle.js` at 240ms, premature remove at 263ms).
- Both switch paths (header toggle, terminal command) now run exactly one transition with `.theme-vt` held throughout and clean teardown.
- New unit test: an echo repeating the in-flight theme starts a single view transition and the flag/class are cleaned up after `finished`.
- `npm run check` green (typecheck + lint + 265 unit tests).