### PR TITLE
feat: film-grain noise overlay

### DIFF
--- a/v2-blog/src/_includes/css/terminal.css
+++ b/v2-blog/src/_includes/css/terminal.css
@@ -143,7 +143,7 @@ body::after {
   inset: 0;
   z-index: 100;
   pointer-events: none;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='128' height='128'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='3' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3C/filter%3E%3Crect width='128' height='128' filter='url(%23n)'/%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='128' height='128'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='turbulence' baseFrequency='0.4' numOctaves='4' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3C/filter%3E%3Crect width='128' height='128' filter='url(%23n)'/%3E%3C/svg%3E");
   background-repeat: repeat;
   opacity: var(--noise-opacity, 0.05);
 }

--- a/v2-blog/src/_includes/css/terminal.css
+++ b/v2-blog/src/_includes/css/terminal.css
@@ -53,6 +53,8 @@ html {
   --term-err-bg: #e5484d;
   --term-warn-bg: #c8860d;
   --term-badge-text: #fff;
+
+  --noise-opacity: 0.05;
 }
 
 html.dark {
@@ -79,6 +81,8 @@ html.dark {
   --term-err-bg: #ff6b6b;
   --term-warn-bg: #ffc857;
   --term-badge-text: #15131f;
+
+  --noise-opacity: 0.08;
 }
 
 @keyframes blink {
@@ -126,6 +130,22 @@ body {
 ::selection {
   background-color: var(--color-accent-primary);
   color: var(--color-bg-default);
+}
+
+/* Film-grain overlay — same pre-rasterized feTurbulence tile as global.css
+   (keep the data URI in sync). A body::after is enough here: the books shell
+   never opts into cross-document view transitions, so the grain has no
+   snapshot group to fall behind, and during a theme swap it flattens into
+   the single root snapshot like everything else. */
+body::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  pointer-events: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='128' height='128'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='3' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3C/filter%3E%3Crect width='128' height='128' filter='url(%23n)'/%3E%3C/svg%3E");
+  background-repeat: repeat;
+  opacity: var(--noise-opacity, 0.05);
 }
 
 ::-moz-selection {

--- a/v2-blog/src/_layouts/base.njk
+++ b/v2-blog/src/_layouts/base.njk
@@ -100,7 +100,8 @@
 
     {{ scriptsOutput | safe }}
   </head>
-  <body class="font-sans dotted-bg noise-fx">
+  <body class="font-sans dotted-bg">
+    <div class="noise-fx" aria-hidden="true"></div>
     <div class="min-h-screen selection:bg-accent selection:text-white flex flex-col">
       
       {% include "partials/header.njk" %}

--- a/v2-blog/src/_layouts/base.njk
+++ b/v2-blog/src/_layouts/base.njk
@@ -100,7 +100,7 @@
 
     {{ scriptsOutput | safe }}
   </head>
-  <body class="font-sans dotted-bg">
+  <body class="font-sans dotted-bg noise-fx">
     <div class="min-h-screen selection:bg-accent selection:text-white flex flex-col">
       
       {% include "partials/header.njk" %}

--- a/v2-blog/src/_layouts/books.njk
+++ b/v2-blog/src/_layouts/books.njk
@@ -75,7 +75,7 @@
 
     <meta 
       http-equiv="Content-Security-Policy" 
-      content="default-src 'self'; script-src {{ cspScriptSrc }}; style-src {{ cspStyleSrc }}; font-src 'self'; base-uri 'self'; object-src 'none'; form-action 'self';"
+      content="default-src 'self'; script-src {{ cspScriptSrc }}; style-src {{ cspStyleSrc }}; font-src 'self'; img-src 'self' data:; base-uri 'self'; object-src 'none'; form-action 'self';"
     >
     <meta name="view-transition" content="same-origin">
     

--- a/v2-blog/src/assets/styles/global.css
+++ b/v2-blog/src/assets/styles/global.css
@@ -213,12 +213,15 @@
 
 /* Film-grain overlay. The tile is a pre-rasterized feTurbulence SVG baked
    into a data URI, so the browser never runs a live full-viewport SVG filter
-   — it paints once as a repeated 128px background. No view-transition-name
-   and no blend mode, so during the .theme-vt sweep it flattens into the
-   single root snapshot and rides the clip-path like everything else.
+   — it paints once as a repeated 128px background.
+   A real element (not a body::before) because it needs its own
+   view-transition-name: <main> is a separate VT group (post) that stacks
+   above root during page navigation, so grain baked only into the root
+   snapshot vanishes behind main's opaque backgrounds mid-crossfade. As its
+   own group (painted last → stacked topmost) the grain stays put; old/new
+   snapshots are identical so the crossfade is invisible.
    Intensity comes from the per-theme --noise-opacity token. */
-.noise-fx::before {
-  content: '';
+.noise-fx {
   position: fixed;
   inset: 0;
   z-index: 100;
@@ -226,6 +229,25 @@
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='128' height='128'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='3' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3C/filter%3E%3Crect width='128' height='128' filter='url(%23n)'/%3E%3C/svg%3E");
   background-repeat: repeat;
   opacity: var(--noise-opacity, 0.05);
+  view-transition-name: noise-fx;
+}
+
+/* The grain never animates during navigation. Kill the default crossfade —
+   old and new snapshots are identical, and fading them across each other
+   would stack two grain layers (intensity visibly doubles mid-transition).
+   Show only the new snapshot at full strength. */
+::view-transition-group(noise-fx),
+::view-transition-old(noise-fx),
+::view-transition-new(noise-fx) {
+  animation: none;
+}
+
+::view-transition-old(noise-fx) {
+  opacity: 0;
+}
+
+::view-transition-new(noise-fx) {
+  opacity: 1;
 }
 
 ::view-transition-old(post) {
@@ -260,10 +282,12 @@
   will-change: auto !important;
 }
 
-/* <main> carries view-transition-name:post for the page-nav morph. During a
-   theme swap that name would split main into its own (fading) group instead of
-   the root clip — drop it so the whole page sweeps as one root snapshot. */
-:root.theme-vt main {
+/* <main> carries view-transition-name:post for the page-nav morph, and the
+   grain overlay carries noise-fx. During a theme swap those names would split
+   them into their own (fading) groups instead of the root clip — drop them so
+   the whole page sweeps as one root snapshot. */
+:root.theme-vt main,
+:root.theme-vt .noise-fx {
   view-transition-name: none;
 }
 

--- a/v2-blog/src/assets/styles/global.css
+++ b/v2-blog/src/assets/styles/global.css
@@ -226,7 +226,7 @@
   inset: 0;
   z-index: 100;
   pointer-events: none;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='128' height='128'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='3' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3C/filter%3E%3Crect width='128' height='128' filter='url(%23n)'/%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='128' height='128'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='turbulence' baseFrequency='0.4' numOctaves='4' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3C/filter%3E%3Crect width='128' height='128' filter='url(%23n)'/%3E%3C/svg%3E");
   background-repeat: repeat;
   opacity: var(--noise-opacity, 0.05);
   view-transition-name: noise-fx;

--- a/v2-blog/src/assets/styles/global.css
+++ b/v2-blog/src/assets/styles/global.css
@@ -114,6 +114,8 @@
     --term-err-bg: #e5484d;
     --term-warn-bg: #c8860d;
     --term-badge-text: #fff;
+
+    --noise-opacity: 0.05;
   }
 
   html.dark {
@@ -156,6 +158,8 @@
     --color-h2: var(--color-pink-400);
     --color-h3: var(--color-gray-400);
     --color-h4: var(--color-gray-500);
+
+    --noise-opacity: 0.08;
   }
 }
 
@@ -205,6 +209,23 @@
       visibility: visible;
     }
   }
+}
+
+/* Film-grain overlay. The tile is a pre-rasterized feTurbulence SVG baked
+   into a data URI, so the browser never runs a live full-viewport SVG filter
+   — it paints once as a repeated 128px background. No view-transition-name
+   and no blend mode, so during the .theme-vt sweep it flattens into the
+   single root snapshot and rides the clip-path like everything else.
+   Intensity comes from the per-theme --noise-opacity token. */
+.noise-fx::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  pointer-events: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='128' height='128'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='3' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3C/filter%3E%3Crect width='128' height='128' filter='url(%23n)'/%3E%3C/svg%3E");
+  background-repeat: repeat;
+  opacity: var(--noise-opacity, 0.05);
 }
 
 ::view-transition-old(post) {


### PR DESCRIPTION
## What

Subtle film-grain noise texture across the site — base shell (pages/posts/notes) and the books terminal shell.

## How

- Grain tile is a pre-rasterized `feTurbulence` SVG baked into a data URI (`turbulence`, `baseFrequency` 0.4, 4 octaves, grayscale via `feColorMatrix`, `stitchTiles` for seamless repeat). No live full-viewport SVG filter — paints once as a repeated 128px background.
- Intensity per theme via `--noise-opacity` token: 0.05 pinky / 0.08 dark, defined in both shells' palettes.
- **Base shell:** real `.noise-fx` element with its own `view-transition-name` — `<main>` is a separate VT group (`post`) that stacks above root during page navigation, so grain baked only into the root snapshot vanished behind opaque backgrounds mid-crossfade. As its own topmost group the grain stays put; old snapshot hidden so identical layers don't stack. Theme swap drops the name (same trick as `main`) so the clip-path sweep still runs on a single root snapshot.
- **Books shell:** plain `body::after` — never opts into cross-document view transitions, no snapshot group to fall behind. Required adding `img-src 'self' data:` to the books CSP (had no `img-src`, data: URIs fell back to `default-src`).

## Verified

- Theme swap both directions on base + books shells: sweep clean, `.theme-vt` cleanup correct, opacity token flips.
- Page navigation with slowed (6s) transition: grain constant over `post` group crossfade, `noise-fx` group active with `animation: none`.
- No CSP violations; `npm run check` green (307 tests).
- Chrome-verified; Safari worth one eyeball pass (spec-defined behavior, no known divergence).