### PR TITLE
refactor: one head-assembly macro for both layouts

### DIFF
--- a/v2-blog/src/_includes/macros/head.njk
+++ b/v2-blog/src/_includes/macros/head.njk
@@ -1,0 +1,56 @@
+{# Head assembly for every layout: the CSP capture/hash/buffer machinery
+   (issue: base.njk and books.njk used to carry a diverging copy each — the
+   books shell shipped without img-src because of it).
+
+   Interface — everything a layout must know:
+     scripts       array of inline-script include paths (relative to
+                   _includes). The layout composes the full ordered list:
+                   its own fixed scripts + the page's `inlineScripts`.
+     styles        array of inline-style include paths, same composition
+                   rule (layout chrome + page `inlineStyles`), in cascade
+                   order.
+     extraStyleSrc extra style-src CSP sources (e.g. a font host), optional.
+
+   Every path is included, trimmed, sha256-hashed into the CSP, and its tag
+   buffered; the macro then prints the CSP meta, the view-transition meta,
+   all <style> tags, and all <script> tags — in that order. Inline content
+   must stay static (any dynamic data goes into markup/data attributes),
+   because the hash is computed at build time.
+
+   `inline-theme.js` is not an argument: every page boots the theme
+   pre-paint, so the macro includes it first unconditionally. #}
+{% macro head(opts) -%}
+  {%- set cspScriptSrc = "'self'" -%}
+  {%- set cspStyleSrc = "'self'" -%}
+  {%- if opts.extraStyleSrc -%}
+    {%- set cspStyleSrc = cspStyleSrc + " " + opts.extraStyleSrc -%}
+  {%- endif -%}
+
+  {%- set scriptsOutput = "" -%}
+  {%- set stylesOutput = "" -%}
+
+  {%- set themeContent -%}{% include "inline-theme.js" %}{%- endset -%}
+  {%- set cspScriptSrc = cspScriptSrc + " " + (themeContent | trim | cspHash) -%}
+  {%- set scriptsOutput = scriptsOutput + '<script>' + (themeContent | safe | trim) + '</script>' -%}
+
+  {%- for path in opts.scripts -%}
+    {%- set content -%}{% include path %}{%- endset -%}
+    {%- set cspScriptSrc = cspScriptSrc + " " + (content | trim | cspHash) -%}
+    {%- set scriptsOutput = scriptsOutput + '<script>' + (content | safe | trim) + '</script>' -%}
+  {%- endfor -%}
+
+  {%- for path in opts.styles -%}
+    {%- set content -%}{% include path %}{%- endset -%}
+    {%- set cspStyleSrc = cspStyleSrc + " " + (content | trim | cspHash) -%}
+    {%- set stylesOutput = stylesOutput + '<style>' + (content | safe | trim) + '</style>' -%}
+  {%- endfor -%}
+
+  <meta
+    http-equiv="Content-Security-Policy"
+    content="default-src 'self'; script-src {{ cspScriptSrc }}; style-src {{ cspStyleSrc }}; font-src 'self'; img-src 'self' data:; base-uri 'self'; object-src 'none'; form-action 'self';"
+  >
+    <meta name="view-transition" content="same-origin">
+
+    {{ stylesOutput | safe }}
+    {{ scriptsOutput | safe }}
+{%- endmacro %}

--- a/v2-blog/src/_layouts/base.njk
+++ b/v2-blog/src/_layouts/base.njk
@@ -6,78 +6,17 @@
     <meta name="description" content="{{ description or metadata.description }}">
     <title>{{ title or "My Portfolio" }}</title>
 
-    
-    {# Start our CSP lists with 'self' #}
-    {% set cspScriptSrc = "'self'" %}
-    {% set cspStyleSrc = "'self'" %}
 
-    {# Initialize buffers to hold the actual HTML tags we want to print later #}
-    {% set scriptsOutput = "" %}
-    {% set stylesOutput = "" %}
-
-    {% set themeContent %}{% include "inline-theme.js" %}{% endset %}
-    {% set themeHash = themeContent | trim | cspHash %}
-
-    {% set cspScriptSrc = cspScriptSrc + " " + themeHash %}
-    {% set scriptsOutput = scriptsOutput + '<script>' + (themeContent | safe | trim) + '</script>' %}
-
-    {# Pre-paint reveal of the cheat-console summon button (#80) #}
-    {% set unlockContent %}{% include "inline-terminal-unlock.js" %}{% endset %}
-    {% set unlockHash = unlockContent | trim | cspHash %}
-    {% set cspScriptSrc = cspScriptSrc + " " + unlockHash %}
-    {% set scriptsOutput = scriptsOutput + '<script>' + (unlockContent | safe | trim) + '</script>' %}
-
-    {# Handle optional page script #}
-    {% if inlineScripts %}
-      {% for path in inlineScripts %}
-        {# 1. Read file #}
-        {% set content %}{% include path %}{% endset %}
-        
-        {# 2. Hash it #}
-        {% set hash = content | trim | cspHash %}
-        {% set cspScriptSrc = cspScriptSrc + " " + hash %}
-        
-        {# 3. Store the tag for later #}
-        {% set scriptsOutput = scriptsOutput + '<script>' + (content | safe | trim) + '</script>' %}
-      {% endfor %}
-    {% endif %}
-
-    {# Global element styles first: they declare the cascade-layer order and
-       live in the `app` layer. Page-specific inline styles (e.g. markdown.css)
-       are injected AFTER, so they win intra-layer conflicts by source order. #}
-    {% set compsCss %}{% include "css/default.css" %}{% endset %}
-    {% set compsHash = compsCss | trim | cspHash %}
-    {% set cspStyleSrc = cspStyleSrc + " " + compsHash %}
-    {% set stylesOutput = stylesOutput + '<style>' + (compsCss | safe | trim) + '</style>' %}
-
-    {% if inlineStyles %}
-      {% for path in inlineStyles %}
-        {# 1. Read file #}
-        {% set content %}{% include path %}{% endset %}
-
-        {# 2. Hash it #}
-        {% set hash = content | trim | cspHash %}
-        {% set cspStyleSrc = cspStyleSrc + " " + hash %}
-
-        {# 3. Store the tag for later #}
-        {% set stylesOutput = stylesOutput + '<style>' + (content | safe | trim) + '</style>' %}
-      {% endfor %}
-    {% endif %}
-
-    {% set fontCss %}{% include "css/fonts.css" %}{% endset %}
-
-    {% set fontHash = fontCss | trim | cspHash %}
-    {% set cspStyleSrc = cspStyleSrc + " " + fontHash %}
-
-    {% set stylesOutput = stylesOutput + '<style>' + (fontCss | safe | trim) + '</style>' %}
-
-    <meta
-      http-equiv="Content-Security-Policy" 
-      content="default-src 'self'; script-src {{ cspScriptSrc }}; style-src {{ cspStyleSrc }}; img-src 'self' data:; base-uri 'self'; object-src 'none'; form-action 'self';"
-    >
-    <meta name="view-transition" content="same-origin">
-    
-    {{ stylesOutput | safe }}
+    {# Head assembly (CSP hashing + inline tags) lives in macros/head.njk.
+       Scripts: the unlock pre-paint reveal (#80) + the page's own.
+       Styles: global element styles first (they declare the cascade-layer
+       order), page styles after (win intra-layer conflicts by source order),
+       fonts last. #}
+    {% import "macros/head.njk" as heads %}
+    {{ heads.head({
+      scripts: ["inline-terminal-unlock.js"].concat(inlineScripts or []),
+      styles: ["css/default.css"].concat(inlineStyles or []).concat(["css/fonts.css"])
+    }) }}
 
     <link rel="preload" href="/assets/css/menu-mobile-shadow.css" as="fetch" crossorigin>
     <link rel="preload" href="/assets/css/toggle-theme-shadow.css" as="fetch" crossorigin>
@@ -97,8 +36,6 @@
         <script type="module" src="{{ url }}"></script>
       {% endfor %}
     {% endif %}
-
-    {{ scriptsOutput | safe }}
   </head>
   <body class="font-sans dotted-bg">
     <div class="noise-fx" aria-hidden="true"></div>

--- a/v2-blog/src/_layouts/books.njk
+++ b/v2-blog/src/_layouts/books.njk
@@ -8,82 +8,18 @@
     <meta name="description" content="{{ description or metadata.description }}">
     <title>{{ title or "My Portfolio" }}</title>
 
-    
-    {# Start our CSP lists with 'self' #}
-    {% set cspScriptSrc = "'self'" %}
-    {% set cspStyleSrc = "'self' https://use.typekit.net" %}
 
-    {# Initialize buffers to hold the actual HTML tags we want to print later #}
-    {% set scriptsOutput = "" %}
-    {% set stylesOutput = "" %}
-
-    {% set themeContent %}{% include "inline-theme.js" %}{% endset %}
-    {% set themeHash = themeContent | trim | cspHash %}
-
-    {% set cspScriptSrc = cspScriptSrc + " " + themeHash %}
-    {% set scriptsOutput = scriptsOutput + '<script>' + (themeContent | safe | trim) + '</script>' %}
-
-    {% set deferredBooksShellCssContent %}{% include "inline-books-shell-css.js" %}{% endset %}
-    {% set deferredBooksShellCssHash = deferredBooksShellCssContent | trim | cspHash %}
-
-    {% set cspScriptSrc = cspScriptSrc + " " + deferredBooksShellCssHash %}
-    {% set scriptsOutput = scriptsOutput + '<script>' + (deferredBooksShellCssContent | safe | trim) + '</script>' %}
-    
-
-    {# Handle optional page script #}
-    {% if inlineScripts %}
-      {% for path in inlineScripts %}
-        {# 1. Read file #}
-        {% set content %}{% include path %}{% endset %}
-        
-        {# 2. Hash it #}
-        {% set hash = content | trim | cspHash %}
-        {% set cspScriptSrc = cspScriptSrc + " " + hash %}
-        
-        {# 3. Store the tag for later #}
-        {% set scriptsOutput = scriptsOutput + '<script>' + (content | safe | trim) + '</script>' %}
-      {% endfor %}
-    {% endif %}
-
-    {% if inlineStyles %}
-      {% for path in inlineStyles %}
-        {# 1. Read file #}
-        {% set content %}{% include path %}{% endset %}
-        
-        {# 2. Hash it #}
-        {% set hash = content | trim | cspHash %}
-        {% set cspStyleSrc = cspStyleSrc + " " + hash %}
-        
-        {# 3. Store the tag for later #}
-        {% set stylesOutput = stylesOutput + '<style>' + (content | safe | trim) + '</style>' %}
-      {% endfor %}
-    {% endif %}
-
-    {% set fontCss %}{% include "css/terminal-fonts.css" %}{% endset %}
-
-    {% set fontHash = fontCss | trim | cspHash %}
-    {% set cspStyleSrc = cspStyleSrc + " " + fontHash %}
-
-    {% set stylesOutput = stylesOutput + '<style>' + (fontCss | safe | trim) + '</style>' %}
-
-    {% set terminalCss %}{% include "css/terminal.css" %}{% endset %}
-
-    {% set terminalHash = terminalCss | trim | cspHash %}
-    {% set cspStyleSrc = cspStyleSrc + " " + terminalHash %}
-
-    {% set stylesOutput = stylesOutput + '<style>' + (terminalCss | safe | trim) + '</style>' %}
-
-    <meta 
-      http-equiv="Content-Security-Policy" 
-      content="default-src 'self'; script-src {{ cspScriptSrc }}; style-src {{ cspStyleSrc }}; font-src 'self'; img-src 'self' data:; base-uri 'self'; object-src 'none'; form-action 'self';"
-    >
-    <meta name="view-transition" content="same-origin">
-    
-    {{ stylesOutput | safe }}
+    {# Head assembly (CSP hashing + inline tags) lives in macros/head.njk.
+       Scripts: the deferred books-shell CSS loader + the page's own.
+       Styles: page styles first, then the terminal fonts + shell CSS. #}
+    {% import "macros/head.njk" as heads %}
+    {{ heads.head({
+      scripts: ["inline-books-shell-css.js"].concat(inlineScripts or []),
+      styles: (inlineStyles or []).concat(["css/terminal-fonts.css", "css/terminal.css"]),
+      extraStyleSrc: "https://use.typekit.net"
+    }) }}
 
     <link rel="preload" href="/assets/fonts/ibm-plex-mono-v20-latin/ibm-plex-mono-v20-latin-regular.woff2" as="font" type="font/woff2" crossorigin/>
-
-    {{ scriptsOutput | safe }}
 
     <script type="module" src="/components/theme-toggle.js"></script>
     <script type="module" src="/components/terminal-shell.js"></script>


### PR DESCRIPTION
## What

Extracts the CSP capture/hash/buffer machinery — duplicated ~50 lines each in `base.njk` and `books.njk` — into a single Nunjucks macro (`_includes/macros/head.njk`).

## Why

The twin copies kept diverging: the books shell shipped without `img-src` this very week (grain tile blocked), the style-src seeds differed, and `font-src` existed in only one copy. CLAUDE.md even carries a "head changes usually need to land in both" gotcha — this deletes the hazard instead of documenting it.

## How

- `heads.head(opts)` owns seeding, hashing (`cspHash`), tag buffering, the CSP meta, and the view-transition meta. `inline-theme.js` is unconditional (every page boots the theme pre-paint).
- Layouts declare only their inputs: ordered inline script/style path lists (layout chrome + page frontmatter arrays) and `extraStyleSrc` (books' typekit host).
- Net −71 lines; layout heads are now ~10 declarative lines each.

## Equivalence check (built baseline diff, master vs branch)

- All CSP hashes byte-identical on home, blog index, post, books listing, book detail.
- Two deliberate diffs only:
  - `font-src 'self'` now on both shells (was books-only; same effective policy — `default-src 'self'` already governed fonts).
  - Inline script tags print right after style tags on both shells (previously after modules on base; head-inline scripts execute pre-paint either way, module scripts are deferred by spec).

## Verified

- `npm run check` green (307 tests).
- `lint:html` error count *drops* 559 → 542 (the remainder is pre-existing noise on master).
- Live in Chrome: zero CSP violations on home + books, theme boot, deferred books-shell CSS loader, and grain tile all working.