### PR TITLE
refactor: land the palette single-source on master (rescue #121)

### DIFF
--- a/v2-blog/src/_helpers/terminal/core.ts
+++ b/v2-blog/src/_helpers/terminal/core.ts
@@ -42,6 +42,30 @@ export function commandBadge(type: CommandType): string | undefined {
   }
 }
 
+/**
+ * Maps a badged line's kind to its decorative glyph. The single source of the
+ * glyph vocabulary (ADR-0002): every surface renders it from the `data-glyph`
+ * attribute via one generic CSS rule, so it stays out of aria text and
+ * persisted scrollback and the surfaces can't drift.
+ *
+ * @param type - The line kind.
+ * @returns The glyph character, or `undefined` for kinds without a badge.
+ */
+export function commandGlyph(type: CommandType): string | undefined {
+  switch (type) {
+    case CommandType.title:
+      return "▮";
+    case CommandType.error:
+      return "✗";
+    case CommandType.status:
+      return "✓";
+    case CommandType.info:
+      return "▸";
+    default:
+      return undefined;
+  }
+}
+
 type TerminalCoreOptions = {
   /** Command registry; consumers register their own command sets. */
   commands: Record<string, CommandHandler>;
@@ -142,11 +166,13 @@ export class TerminalCore {
     const lines = String(text).replace(/\r\n/g, "\n").split("\n");
 
     const badge = commandBadge(kind);
+    const glyph = commandGlyph(kind);
 
     for (const line of lines) {
       const p = document.createElement("p");
       p.className = `terminal-msg ${CommandType[kind]}`;
       if (badge) p.dataset.badge = badge;
+      if (glyph) p.dataset.glyph = glyph;
       p.textContent = "";
       log.appendChild(p);
 
@@ -199,6 +225,8 @@ export class TerminalCore {
     p.className = `terminal-msg ${CommandType[kind]}`;
     const badge = commandBadge(kind);
     if (badge) p.dataset.badge = badge;
+    const glyph = commandGlyph(kind);
+    if (glyph) p.dataset.glyph = glyph;
     p.textContent = text;
     return p;
   }

--- a/v2-blog/src/_includes/css/term-palette.css
+++ b/v2-blog/src/_includes/css/term-palette.css
@@ -1,0 +1,71 @@
+/* Terminal palette + shared colour ramps (ADR-0002) — the single source.
+   Consumed twice:
+   - global.css `@import`s it into the theme layer (base shell), and
+   - the books shell inlines it ahead of terminal.css via the head macro.
+   The --term-* set derives from the active theme's pink hue and brightness;
+   --noise-opacity / --noise-tile drive the film-grain overlay on both shells.
+   Nothing here may reference tokens defined elsewhere. */
+
+:root,
+:host,
+html {
+  --color-gray-50: #fafaf9;
+  --color-gray-100: #f5f5f4;
+  --color-gray-200: #e7e5e4;
+  --color-gray-300: #d6d3d1;
+  --color-gray-400: #a8a29e;
+  --color-gray-500: #78716c;
+  --color-gray-600: #57534e;
+  --color-gray-700: #44403c;
+  --color-gray-800: #292524;
+  --color-gray-900: #1c1917;
+  --color-gray-950: #0c0a09;
+
+  --color-pink-50: #fffbfc;
+  --color-pink-100: #fdcfda;
+  --color-pink-200: #fba7bb;
+  --color-pink-300: #f9839f;
+  --color-pink-400: #f86285;
+  --color-pink-500: #f7446d;
+  --color-pink-600: #f62655;
+  --color-pink-700: #f50b40;
+  --color-pink-800: #dd0939;
+  --color-pink-900: #c70833;
+  --color-pink-950: #b3072e;
+
+  /* Terminal palette. Background uses the theme default; surface, border and
+     text share the pink accent hue. */
+  --term-bg: var(--color-bg-default);
+  --term-surface: color-mix(in oklab, var(--color-accent-primary) 12%, white);
+  --term-border: color-mix(in oklab, var(--color-accent-primary) 28%, white);
+  --term-text: color-mix(in oklab, var(--color-accent-primary) 78%, black);
+  --term-muted: color-mix(in oklab, var(--color-accent-primary) 45%, var(--color-gray-500));
+  --term-accent: var(--color-accent-primary);
+  --term-on-accent: var(--color-pink-50);
+  --term-prompt: var(--color-accent-primary);
+  --term-ok-bg: #2fa46a;
+  --term-err-bg: #e5484d;
+  --term-warn-bg: #c8860d;
+  --term-badge-text: #fff;
+
+  /* Film-grain overlay: pre-rasterized feTurbulence tile + per-theme
+     strength. Consumers paint var(--noise-tile) on a fixed overlay. */
+  --noise-opacity: 0.05;
+  --noise-tile: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='128' height='128'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='turbulence' baseFrequency='0.4' numOctaves='4' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3C/filter%3E%3Crect width='128' height='128' filter='url(%23n)'/%3E%3C/svg%3E");
+}
+
+html.dark {
+  /* Dark theme: same pink hue, mixed toward black (ADR-0002). */
+  --term-bg: var(--color-bg-default);
+  --term-surface: color-mix(in oklab, var(--color-accent-primary) 14%, #0c0a14);
+  --term-border: color-mix(in oklab, var(--color-accent-primary) 22%, var(--color-gray-800));
+  --term-text: color-mix(in oklab, var(--color-accent-primary) 32%, white);
+  --term-muted: color-mix(in oklab, var(--color-accent-primary) 45%, var(--color-gray-500));
+  --term-on-accent: var(--color-gray-900);
+  --term-ok-bg: #46d18a;
+  --term-err-bg: #ff6b6b;
+  --term-warn-bg: #ffc857;
+  --term-badge-text: #15131f;
+
+  --noise-opacity: 0.08;
+}

--- a/v2-blog/src/_includes/css/terminal.css
+++ b/v2-blog/src/_includes/css/terminal.css
@@ -1,31 +1,9 @@
 
+/* Colour ramps, --term-*, and --noise-* tokens come from term-palette.css,
+   inlined ahead of this file by the head macro (single source, ADR-0002). */
 :root,
 :host,
 html {
-  --color-gray-50: #fafaf9;
-  --color-gray-100: #f5f5f4;
-  --color-gray-200: #e7e5e4;
-  --color-gray-300: #d6d3d1;
-  --color-gray-400: #a8a29e;
-  --color-gray-500: #78716c;
-  --color-gray-600: #57534e;
-  --color-gray-700: #44403c;
-  --color-gray-800: #292524;
-  --color-gray-900: #1c1917;
-  --color-gray-950: #0c0a09;
-
-  --color-pink-50: #fffbfc;
-  --color-pink-100: #fdcfda;
-  --color-pink-200: #fba7bb;
-  --color-pink-300: #f9839f;
-  --color-pink-400: #f86285;
-  --color-pink-500: #f7446d;
-  --color-pink-600: #f62655;
-  --color-pink-700: #f50b40;
-  --color-pink-800: #dd0939;
-  --color-pink-900: #c70833;
-  --color-pink-950: #b3072e;
-
   --color-text-primary: var(--color-gray-800);
   --color-bg-default: var(--color-pink-50);
 
@@ -38,23 +16,6 @@ html {
   --color-text: var(--color-text-primary);
 
   --font-mono: 'IBM Plex Mono', ui-monospace, 'Cascadia Code', 'Source Code Pro', 'Menlo', 'Monaco', 'Consolas', 'Roboto Mono', 'Courier New', monospace;
-
-  /* Terminal palette (ADR-0002). Background uses the theme default; surface,
-     border and text share the pink accent hue. Keep in sync with global.css. */
-  --term-bg: var(--color-bg-default);
-  --term-surface: color-mix(in oklab, var(--color-accent-primary) 12%, white);
-  --term-border: color-mix(in oklab, var(--color-accent-primary) 28%, white);
-  --term-text: color-mix(in oklab, var(--color-accent-primary) 78%, black);
-  --term-muted: color-mix(in oklab, var(--color-accent-primary) 45%, var(--color-gray-500));
-  --term-accent: var(--color-accent-primary);
-  --term-on-accent: var(--color-pink-50);
-  --term-prompt: var(--color-accent-primary);
-  --term-ok-bg: #2fa46a;
-  --term-err-bg: #e5484d;
-  --term-warn-bg: #c8860d;
-  --term-badge-text: #fff;
-
-  --noise-opacity: 0.05;
 }
 
 html.dark {
@@ -69,20 +30,6 @@ html.dark {
   --color-code-bg: var(--color-gray-900);
   --color-code-border: var(--color-gray-800);
   --color-text: var(--color-text-primary);
-
-  /* Dark theme: same pink hue, mixed toward black (ADR-0002). */
-  --term-bg: var(--color-bg-default);
-  --term-surface: color-mix(in oklab, var(--color-accent-primary) 14%, #0c0a14);
-  --term-border: color-mix(in oklab, var(--color-accent-primary) 22%, var(--color-gray-800));
-  --term-text: color-mix(in oklab, var(--color-accent-primary) 32%, white);
-  --term-muted: color-mix(in oklab, var(--color-accent-primary) 45%, var(--color-gray-500));
-  --term-on-accent: var(--color-gray-900);
-  --term-ok-bg: #46d18a;
-  --term-err-bg: #ff6b6b;
-  --term-warn-bg: #ffc857;
-  --term-badge-text: #15131f;
-
-  --noise-opacity: 0.08;
 }
 
 @keyframes blink {
@@ -143,7 +90,7 @@ body::after {
   inset: 0;
   z-index: 100;
   pointer-events: none;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='128' height='128'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='turbulence' baseFrequency='0.4' numOctaves='4' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3C/filter%3E%3Crect width='128' height='128' filter='url(%23n)'/%3E%3C/svg%3E");
+  background-image: var(--noise-tile);
   background-repeat: repeat;
   opacity: var(--noise-opacity, 0.05);
 }

--- a/v2-blog/src/_layouts/books.njk
+++ b/v2-blog/src/_layouts/books.njk
@@ -11,11 +11,12 @@
 
     {# Head assembly (CSP hashing + inline tags) lives in macros/head.njk.
        Scripts: the deferred books-shell CSS loader + the page's own.
-       Styles: page styles first, then the terminal fonts + shell CSS. #}
+       Styles: the shared terminal palette first (single token source,
+       ADR-0002), page styles, then the terminal fonts + shell CSS. #}
     {% import "macros/head.njk" as heads %}
     {{ heads.head({
       scripts: ["inline-books-shell-css.js"].concat(inlineScripts or []),
-      styles: (inlineStyles or []).concat(["css/terminal-fonts.css", "css/terminal.css"]),
+      styles: ["css/term-palette.css"].concat(inlineStyles or []).concat(["css/terminal-fonts.css", "css/terminal.css"]),
       extraStyleSrc: "https://use.typekit.net"
     }) }}
 

--- a/v2-blog/src/assets/styles/books-terminal-deferred.css
+++ b/v2-blog/src/assets/styles/books-terminal-deferred.css
@@ -100,9 +100,10 @@ html.dark {
   }
 
   /* Linear-stream lines: command echoes get a prompt glyph; info/title/error/
-     status get an uppercase badge pill from the core's data-badge attribute.
-     Glyphs live here (CSS content) so aria text and persisted scrollback stay
-     clean — keep the set in sync with the overlay's shadow styles (ADR-0002). */
+     status get an uppercase badge pill. Glyph + label both come from the
+     core's data attributes (commandGlyph/commandBadge — the single glyph
+     source, ADR-0002), so the pill rule is generic and the per-kind rules
+     below carry colours only. */
   .terminal-msg {
     display: flex;
     flex-wrap: wrap;
@@ -112,7 +113,7 @@ html.dark {
   }
 
   .terminal-msg[data-badge]::before {
-    content: attr(data-badge);
+    content: attr(data-glyph) " " attr(data-badge);
     flex: none;
     align-self: flex-start;
     padding: 0 0.6ch;
@@ -125,24 +126,17 @@ html.dark {
   }
 
   .info[data-badge]::before {
-    content: "▸ " attr(data-badge);
     background: transparent;
     border: 1px solid var(--term-border);
     color: var(--term-text);
   }
 
-  .title[data-badge]::before {
-    content: "▮ " attr(data-badge);
-  }
-
   .error[data-badge]::before {
-    content: "✗ " attr(data-badge);
     background: var(--term-err-bg);
     color: var(--term-badge-text);
   }
 
   .status[data-badge]::before {
-    content: "✓ " attr(data-badge);
     background: var(--term-ok-bg);
     border: 1px solid var(--term-ok-bg);
     color: var(--term-badge-text);

--- a/v2-blog/src/assets/styles/global.css
+++ b/v2-blog/src/assets/styles/global.css
@@ -4,6 +4,9 @@
 /* @import "tailwindcss/preflight.css" layer(base); */
 /* @import "tailwindcss/utilities.css" layer(utilities); */
 @import './config-theme.css';
+/* Terminal palette + colour ramps + noise tokens: single source shared with
+   the books shell (inlined there via the head macro). */
+@import '../../_includes/css/term-palette.css' layer(theme);
 
 @custom-variant dark (&:where(.dark, .dark *));
 
@@ -47,31 +50,8 @@
 
 @layer theme {
 
+  /* Colour ramps live in term-palette.css (imported above). */
   :root, :host, html {
-    --color-gray-50: #fafaf9;
-    --color-gray-100: #f5f5f4;
-    --color-gray-200: #e7e5e4;
-    --color-gray-300: #d6d3d1;
-    --color-gray-400: #a8a29e;
-    --color-gray-500: #78716c;
-    --color-gray-600: #57534e;
-    --color-gray-700: #44403c;
-    --color-gray-800: #292524;
-    --color-gray-900: #1c1917;
-    --color-gray-950: #0c0a09;
-
-    --color-pink-50: #fffbfc;
-    --color-pink-100: #fdcfda;
-    --color-pink-200: #fba7bb;
-    --color-pink-300: #f9839f;
-    --color-pink-400: #f86285;
-    --color-pink-500: #f7446d;
-    --color-pink-600: #f62655;
-    --color-pink-700: #f50b40;
-    --color-pink-800: #dd0939;
-    --color-pink-900: #c70833;
-    --color-pink-950: #b3072e;
-
     --color-text-primary: var(--color-gray-800);
     --color-text-secondary: var(--color-gray-600);
     --color-text-muted: var(--color-gray-400);
@@ -100,22 +80,7 @@
     --color-h3: color-mix(in oklab, var(--color-pink-950) 90%, white 10%);
     --color-h4: color-mix(in oklab, var(--color-pink-950) 95%, white 5%);
 
-    /* Terminal palette (ADR-0002). Background uses the theme default; surface,
-       border and text share the pink accent hue. Keep in sync with terminal.css. */
-    --term-bg: var(--color-bg-default);
-    --term-surface: color-mix(in oklab, var(--color-accent-primary) 12%, white);
-    --term-border: color-mix(in oklab, var(--color-accent-primary) 28%, white);
-    --term-text: color-mix(in oklab, var(--color-accent-primary) 78%, black);
-    --term-muted: color-mix(in oklab, var(--color-accent-primary) 45%, var(--color-gray-500));
-    --term-accent: var(--color-accent-primary);
-    --term-on-accent: var(--color-pink-50);
-    --term-prompt: var(--color-accent-primary);
-    --term-ok-bg: #2fa46a;
-    --term-err-bg: #e5484d;
-    --term-warn-bg: #c8860d;
-    --term-badge-text: #fff;
-
-    --noise-opacity: 0.05;
+    /* --term-* and --noise-* tokens live in term-palette.css (ADR-0002). */
   }
 
   html.dark {
@@ -142,24 +107,10 @@
     --color-scroll-thumb: var(--color-gray-700);
     --color-sidebar: var(--color-gray-800);
 
-    /* Dark theme: same pink hue, mixed toward black (ADR-0002). */
-    --term-bg: var(--color-bg-default);
-    --term-surface: color-mix(in oklab, var(--color-accent-primary) 14%, #0c0a14);
-    --term-border: color-mix(in oklab, var(--color-accent-primary) 22%, var(--color-gray-800));
-    --term-text: color-mix(in oklab, var(--color-accent-primary) 32%, white);
-    --term-muted: color-mix(in oklab, var(--color-accent-primary) 45%, var(--color-gray-500));
-    --term-on-accent: var(--color-gray-900);
-    --term-ok-bg: #46d18a;
-    --term-err-bg: #ff6b6b;
-    --term-warn-bg: #ffc857;
-    --term-badge-text: #15131f;
-
     --color-h1: var(--color-accent-primary);
     --color-h2: var(--color-pink-400);
     --color-h3: var(--color-gray-400);
     --color-h4: var(--color-gray-500);
-
-    --noise-opacity: 0.08;
   }
 }
 
@@ -226,7 +177,7 @@
   inset: 0;
   z-index: 100;
   pointer-events: none;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='128' height='128'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='turbulence' baseFrequency='0.4' numOctaves='4' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3C/filter%3E%3Crect width='128' height='128' filter='url(%23n)'/%3E%3C/svg%3E");
+  background-image: var(--noise-tile);
   background-repeat: repeat;
   opacity: var(--noise-opacity, 0.05);
   view-transition-name: noise-fx;

--- a/v2-blog/src/components/terminal-overlay.ts
+++ b/v2-blog/src/components/terminal-overlay.ts
@@ -163,8 +163,12 @@ export class TerminalOverlay extends LitElement {
       margin-block-end: 0.6ch;
     }
 
+    /* Badge pill: glyph + label both come from the core's data attributes
+       (commandGlyph/commandBadge — the single glyph source, ADR-0002), so
+       aria text and persisted scrollback stay clean and this rule is
+       generic. Per-kind rules below carry colours only. */
     .terminal-msg[data-badge]::before {
-      content: attr(data-badge);
+      content: attr(data-glyph) " " attr(data-badge);
       flex: none;
       align-self: flex-start;
       padding: 0 0.6ch;
@@ -181,27 +185,18 @@ export class TerminalOverlay extends LitElement {
       margin-block-end: 0;
     }
 
-    /* Glyphs live in CSS content so aria text and persisted scrollback stay
-       clean — keep the set in sync with books-terminal-deferred.css (ADR-0002). */
     .terminal-msg.info[data-badge]::before {
-      content: "▸ " attr(data-badge);
       background: transparent;
       border: 1px solid var(--term-border);
       color: var(--term-text);
     }
 
-    .terminal-msg.title[data-badge]::before {
-      content: "▮ " attr(data-badge);
-    }
-
     .terminal-msg.error[data-badge]::before {
-      content: "✗ " attr(data-badge);
       background: var(--term-err-bg);
       color: var(--term-badge-text);
     }
 
     .terminal-msg.status[data-badge]::before {
-      content: "✓ " attr(data-badge);
       background: var(--term-ok-bg);
       border: 1px solid var(--term-ok-bg);
       color: var(--term-badge-text);

--- a/v2-blog/tests/unit/helpers/terminal/command-badge.test.ts
+++ b/v2-blog/tests/unit/helpers/terminal/command-badge.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { CommandType, commandBadge } from "../../../../src/_helpers/terminal/core.ts";
+import { CommandType, commandBadge, commandGlyph } from "../../../../src/_helpers/terminal/core.ts";
 
 describe("commandBadge", () => {
   it("labels title, error, status, and info lines", () => {
@@ -14,5 +14,28 @@ describe("commandBadge", () => {
     expect(commandBadge(CommandType.command)).toBeUndefined();
     expect(commandBadge(CommandType.log)).toBeUndefined();
     expect(commandBadge(CommandType.logdata)).toBeUndefined();
+  });
+});
+
+describe("commandGlyph", () => {
+  it("marks title, error, status, and info lines", () => {
+    expect(commandGlyph(CommandType.title)).toBe("▮");
+    expect(commandGlyph(CommandType.error)).toBe("✗");
+    expect(commandGlyph(CommandType.status)).toBe("✓");
+    expect(commandGlyph(CommandType.info)).toBe("▸");
+  });
+
+  it("badge and glyph cover exactly the same kinds", () => {
+    for (const kind of [
+      CommandType.log,
+      CommandType.logdata,
+      CommandType.command,
+      CommandType.title,
+      CommandType.error,
+      CommandType.status,
+      CommandType.info,
+    ]) {
+      expect(commandGlyph(kind) === undefined).toBe(commandBadge(kind) === undefined);
+    }
   });
 });

--- a/v2-blog/tests/unit/helpers/terminal/core.test.ts
+++ b/v2-blog/tests/unit/helpers/terminal/core.test.ts
@@ -68,6 +68,16 @@ describe("TerminalCore", () => {
     expect(logEl.querySelector("p.log")?.hasAttribute("data-badge")).toBe(false);
   });
 
+  it("stamps the data-glyph alongside the badge (single glyph source for every surface)", async () => {
+    const { core, logEl } = createCore();
+
+    await core.append("uh oh", 0, CommandType.error);
+    await core.append("plain", 0, CommandType.log);
+
+    expect(logEl.querySelector("p.error")?.getAttribute("data-glyph")).toBe("✗");
+    expect(logEl.querySelector("p.log")?.hasAttribute("data-glyph")).toBe(false);
+  });
+
   it("notifies onLineWritten after each appended line", async () => {
     const onLineWritten = vi.fn();
     const { core, logEl } = createCore({ onLineWritten });
@@ -87,6 +97,7 @@ describe("TerminalCore", () => {
       const p = logEl.querySelector("p.terminal-msg.status")!;
       expect(p.textContent).toBe("hi there");
       expect(p.getAttribute("data-badge")).toBe("OK");
+      expect(p.getAttribute("data-glyph")).toBe("✓");
     });
 
     it("renders a columns block as a grid with tone/align on cells, padding short rows", async () => {


### PR DESCRIPTION
#121 was stacked on `refactor/head-macro` and got merged into that base branch *after* #120 had already landed it on master — so the palette work never reached master. This PR carries exactly #121's content (term-palette.css single source + badge glyphs via commandGlyph); see #121 for the full description and verification notes.