### PR TITLE
refactor: derive build targets from conventions in eleventy config

### DIFF
--- a/v2-blog/CLAUDE.md
+++ b/v2-blog/CLAUDE.md
@@ -21,9 +21,9 @@ npm run test:e2e     # playwright
 ## Build pipeline (eleventy.config.ts — everything happens here)
 
 1. **Eleventy runs through tsx** so the config itself is TypeScript (`--config=eleventy.config.ts`).
-2. **TS → browser JS**: a custom `addExtension("ts", ...)` compiles **only** files under `src/components/` and `src/_helpers/` with esbuild (bundled ESM, minified, es2020). Output mirrors the source path, so `src/components/theme-toggle.ts` is served as `/components/theme-toggle.js`. Any other `.ts` under `src/` is skipped (returns no output).
-3. **Tailwind v4 is compiled manually** in the `eleventy.before` hook via PostCSS (tailwind + autoprefixer + cssnano). There is a hardcoded `targets` array mapping `src/assets/styles/*.css` → `dist/assets/css/*.css`. **A new shadow/global CSS file does nothing until it's added to that array** (or to a passthrough copy, like `books-terminal-deferred.css`).
-4. Passthrough copies: images, fonts, videos, `asciiart/` JSON, and the deferred books CSS.
+2. **TS → browser JS**: a custom `addExtension("ts", ...)` compiles files under `src/components/` and `src/_helpers/` with esbuild (bundled ESM, minified, es2020). Output mirrors the source path, so `src/components/theme-toggle.ts` is served as `/components/theme-toggle.js`. The rules live in `src/_config/buildConventions.ts` (`classifyTsInput`): `.d.ts` files and known non-browser TS (`src/@types/`, `src/_config/`) are ignored; **any other `.ts` under `src/` fails the build** with an error naming the file — move it under `src/components|src/_helpers` or add it to the ignore list.
+3. **Tailwind v4 is compiled manually** in the `eleventy.before` hook via PostCSS (tailwind + autoprefixer + cssnano). Targets are discovered by convention (`cssTargets` in `src/_config/buildConventions.ts`): **every** `src/assets/styles/*.css` compiles to `dist/assets/css/<basename>` — a new shadow/global CSS file just works. Exception: `@import`-only partials (`config-theme.css`, `shadow-config.css`) are listed in `CSS_PARTIALS` there and produce no standalone output. `books-terminal-deferred.css` goes through the same pipeline (no passthrough copy anymore).
+4. Passthrough copies: images, fonts, videos, and `asciiart/` JSON.
 5. Markdown uses markdown-it + markdown-it-anchor with slugified header permalinks; templates render with Nunjucks (`markdownTemplateEngine: "njk"`).
 
 ## CSP pattern (the most fragile part of the head)
@@ -79,7 +79,6 @@ Both layouts build the `Content-Security-Policy` meta tag **at build time** by h
 
 ## Gotchas checklist
 
-- New shadow CSS file → add to the Tailwind `targets` array in `eleventy.config.ts`.
 - New inline script/style → follow the CSP capture/hash/buffer pattern in the layout; keep it static.
 - `src/_layouts/books.njk` duplicates the CSP machinery from `base.njk` — head changes usually need to land in both.
 - Changing a page's `permalink` can break the Lighthouse route list (`.lighthouserc*.json`) and the frontmatter tests.

--- a/v2-blog/eleventy.config.ts
+++ b/v2-blog/eleventy.config.ts
@@ -15,6 +15,7 @@ import tailwindcss from '@tailwindcss/postcss';
 import collections from './src/_config/collections.js';
 import shortcodes from "./src/_config/shortcodes.js";
 import filters from './src/_config/filters.js';
+import { classifyTsInput, cssTargets } from './src/_config/buildConventions.js';
 
 export default function (eleventyConfig: any) {
 
@@ -30,8 +31,9 @@ export default function (eleventyConfig: any) {
   eleventyConfig.addExtension("ts", {
     outputFileExtension: "js", // Output as .js
     compile: async (_: any, inputPath: string) => {
-      // Skip files outside the '_helpers and components' directory 
-      if (!inputPath.includes("_helpers") && !inputPath.includes("components")) return;
+      // Convention: src/components/ and src/_helpers/ compile to browser JS,
+      // known non-browser TS is ignored, anything else throws (no silent skip).
+      if (classifyTsInput(inputPath) === "ignore") return;
 
       return async (_: any) => {
         // Compile using esbuild
@@ -83,36 +85,11 @@ export default function (eleventyConfig: any) {
 
   // Compile tailwind
   eleventyConfig.on('eleventy.before', async () => {
-    // INPUT: Where your source CSS lives
-    // const tailwindInputPath = path.resolve('./src/assets/styles/global.css');
-    // 1. Define your compilation targets
-
-    const targets = [
-      {
-        input: './src/assets/styles/global.css',
-        output: './dist/assets/css/global.css'
-      },
-      {
-        input: './src/assets/styles/shadow.css',
-        output: './dist/assets/css/shadow.css'
-      },
-      {
-        input: './src/assets/styles/toggle-theme-shadow.css',
-        output: './dist/assets/css/toggle-theme-shadow.css'
-      },
-      {
-        input: './src/assets/styles/note-modal-shadow.css',
-        output: './dist/assets/css/note-modal-shadow.css'
-      },
-      {
-        input: './src/assets/styles/menu-mobile-shadow.css',
-        output: './dist/assets/css/menu-mobile-shadow.css'
-      },
-      {
-        input: './src/assets/styles/terminal-overlay-shadow.css',
-        output: './dist/assets/css/terminal-overlay-shadow.css'
-      }
-    ];
+    // Convention: every src/assets/styles/*.css (minus @import-only partials)
+    // compiles to dist/assets/css/<basename> — see src/_config/buildConventions.ts.
+    const styleDir = './src/assets/styles';
+    const styleFiles = fs.readdirSync(path.resolve(styleDir));
+    const targets = cssTargets(styleDir, './dist/assets/css', styleFiles);
 
     for (const target of targets) {
       const inputPath = path.resolve(target.input);
@@ -280,10 +257,6 @@ export default function (eleventyConfig: any) {
 
   eleventyConfig.addPassthroughCopy({
     "src/assets/asciiart": "assets/asciiart"
-  });
-
-  eleventyConfig.addPassthroughCopy({
-    "src/assets/styles/books-terminal-deferred.css": "assets/css/books-terminal-deferred.css"
   });
 
   eleventyConfig.addPassthroughCopy({ "src/_headers": "_headers" });

--- a/v2-blog/src/_config/buildConventions.ts
+++ b/v2-blog/src/_config/buildConventions.ts
@@ -1,0 +1,74 @@
+/**
+ * Build conventions for eleventy.config.ts.
+ *
+ * Pure functions only — no fs access. The config reads the filesystem and
+ * feeds file lists in, so both conventions stay unit-testable.
+ */
+
+/** Directories whose TypeScript is compiled to browser JS (bundled ESM). */
+const TS_COMPILE_DIRS = ["src/components/", "src/_helpers/"];
+
+/**
+ * Known non-browser TypeScript that the build must skip. Path prefixes,
+ * relative to the project root (no leading "./").
+ */
+const TS_IGNORED_PREFIXES = [
+  "src/@types/", // ambient type declarations, never shipped
+  "src/_config/", // node-side build config (this module included), never shipped
+];
+
+/**
+ * Stylesheets in src/assets/styles/ that are @import-only partials — they are
+ * inlined into the sheets that import them and must not become standalone
+ * outputs in dist/assets/css/.
+ */
+const CSS_PARTIALS = new Set(["config-theme.css", "shadow-config.css"]);
+
+function normalize(inputPath: string): string {
+  return inputPath.replace(/\\/g, "/").replace(/^\.\//, "");
+}
+
+/**
+ * Decide what the build does with a `.ts` file Eleventy picked up.
+ *
+ * - under src/components/ or src/_helpers/ → "compile" (esbuild → browser JS)
+ * - declaration files (.d.ts) or paths on the ignore list → "ignore"
+ * - anything else → build error. No silent skips: move the file under
+ *   src/components/ or src/_helpers/, or add it to the ignore list here.
+ */
+export function classifyTsInput(inputPath: string): "compile" | "ignore" {
+  const normalized = normalize(inputPath);
+
+  if (normalized.endsWith(".d.ts")) return "ignore";
+  if (TS_IGNORED_PREFIXES.some((prefix) => normalized.startsWith(prefix))) {
+    return "ignore";
+  }
+  if (TS_COMPILE_DIRS.some((dir) => normalized.includes(dir))) {
+    return "compile";
+  }
+
+  throw new Error(
+    `[build] TypeScript file "${inputPath}" does not match the build convention. ` +
+      `Move it under src/components/ or src/_helpers/ to compile it for the browser, ` +
+      `or add it to the ignore list in src/_config/buildConventions.ts.`
+  );
+}
+
+/**
+ * Derive the Tailwind/PostCSS compilation targets from a directory listing:
+ * every `*.css` in `styleDir` (except @import-only partials) compiles to
+ * `outDir/<basename>`.
+ */
+export function cssTargets(
+  styleDir: string,
+  outDir: string,
+  files: string[]
+): { input: string; output: string }[] {
+  return files
+    .filter((file) => file.endsWith(".css") && !CSS_PARTIALS.has(file))
+    .sort()
+    .map((file) => ({
+      input: `${styleDir}/${file}`,
+      output: `${outDir}/${file}`,
+    }));
+}

--- a/v2-blog/tests/unit/config/buildConventions.test.ts
+++ b/v2-blog/tests/unit/config/buildConventions.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+
+import { classifyTsInput, cssTargets } from "../../../src/_config/buildConventions.js";
+
+describe("classifyTsInput", () => {
+  it("compiles TypeScript under src/components/", () => {
+    expect(classifyTsInput("./src/components/theme-toggle.ts")).toBe("compile");
+  });
+
+  it("compiles TypeScript under src/_helpers/", () => {
+    expect(classifyTsInput("./src/_helpers/theme.ts")).toBe("compile");
+  });
+
+  it("compiles nested TypeScript under src/_helpers/", () => {
+    expect(classifyTsInput("./src/_helpers/terminal/core.ts")).toBe("compile");
+  });
+
+  it("ignores declaration files", () => {
+    expect(classifyTsInput("./src/@types/eleventy-img.d.ts")).toBe("ignore");
+  });
+
+  it("ignores paths on the explicit ignore list", () => {
+    expect(classifyTsInput("./src/@types/some-module.ts")).toBe("ignore");
+  });
+
+  it("ignores node-side config modules under src/_config/", () => {
+    expect(classifyTsInput("./src/_config/buildConventions.ts")).toBe("ignore");
+  });
+
+  it("throws on TypeScript outside the convention, naming the file", () => {
+    expect(() => classifyTsInput("./src/stray.ts")).toThrowError(
+      /src\/stray\.ts/
+    );
+  });
+
+  it("states the convention in the error message", () => {
+    expect(() => classifyTsInput("./src/pages/oops.ts")).toThrowError(
+      /src\/components|src\/_helpers/
+    );
+  });
+});
+
+describe("cssTargets", () => {
+  const styleDir = "./src/assets/styles";
+  const outDir = "./dist/assets/css";
+
+  it("maps every stylesheet to an output with the same basename", () => {
+    const targets = cssTargets(styleDir, outDir, ["global.css", "shadow.css"]);
+    expect(targets).toEqual([
+      {
+        input: "./src/assets/styles/global.css",
+        output: "./dist/assets/css/global.css",
+      },
+      {
+        input: "./src/assets/styles/shadow.css",
+        output: "./dist/assets/css/shadow.css",
+      },
+    ]);
+  });
+
+  it("includes the deferred books stylesheet like any other target", () => {
+    const targets = cssTargets(styleDir, outDir, ["books-terminal-deferred.css"]);
+    expect(targets).toEqual([
+      {
+        input: "./src/assets/styles/books-terminal-deferred.css",
+        output: "./dist/assets/css/books-terminal-deferred.css",
+      },
+    ]);
+  });
+
+  it("excludes @import-only partials from the target list", () => {
+    const targets = cssTargets(styleDir, outDir, [
+      "config-theme.css",
+      "global.css",
+      "shadow-config.css",
+    ]);
+    expect(targets.map((t) => t.input)).toEqual([
+      "./src/assets/styles/global.css",
+    ]);
+  });
+
+  it("skips non-CSS directory entries", () => {
+    const targets = cssTargets(styleDir, outDir, [".DS_Store", "global.css"]);
+    expect(targets.map((t) => t.input)).toEqual([
+      "./src/assets/styles/global.css",
+    ]);
+  });
+
+  it("returns targets in a stable sorted order", () => {
+    const targets = cssTargets(styleDir, outDir, ["shadow.css", "global.css"]);
+    expect(targets.map((t) => t.input)).toEqual([
+      "./src/assets/styles/global.css",
+      "./src/assets/styles/shadow.css",
+    ]);
+  });
+});


### PR DESCRIPTION
## What

Replaces the two literal registries in `eleventy.config.ts` with conventions, backed by pure, unit-tested functions in `src/_config/buildConventions.ts`:

- **Tailwind targets**: every `src/assets/styles/*.css` now compiles to `dist/assets/css/<basename>` automatically (`cssTargets`). `@import`-only partials (`config-theme.css`, `shadow-config.css`) are excluded via a documented `CSS_PARTIALS` set. `books-terminal-deferred.css` goes through the same pipeline — its special passthrough copy is gone (same URL, now minified).
- **TS compilation**: `classifyTsInput` encodes the compile scope (`src/components/`, `src/_helpers/`) and an explicit ignore list (`.d.ts`, `src/@types/`, `src/_config/`). Any other `.ts` under `src/` now **fails the build** with an error naming the file and the fix — no more silent no-output skips.

## Why

Omission failed silently: a new shadow CSS file did nothing until hand-added to the hardcoded `targets` array, and a misplaced `.ts` produced no output with no signal. The knowledge lived in CLAUDE.md gotchas instead of the build itself. Convention + hard error moves it into the module; the "add to the targets array" gotcha is deleted from CLAUDE.md.

The new hard error caught `buildConventions.ts` itself on first run (it lives under Eleventy's input dir) — proof the failure mode is now loud.

## Verification

- `npm run check` green: typecheck + eslint + stylelint + vitest, 336 tests (323 → 336, +13 for the conventions).
- Built with old and new config: **output file set identical** (127 files). `books-terminal-deferred.css` present at the same URL, non-empty.
