### PR TITLE
refactor: extract media-preview scroll policy into a pure module

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -72,6 +72,10 @@ _Avoid_: grace period, open state
 The pure state machine that decides the Media preview's show/hide sequencing — Hover intent, Warm state, the album shape-swap defer, and generation superseding. Owns no DOM, timers, or `window`; the singleton feeds it real events (reveal/commit/hide/stop, timer and transition completions) and executes the commands it returns. See [ADR-0006](docs/adr/0006-preview-faces-and-waapi-animation.md).
 _Avoid_: state machine (as the primary term in prose), controller, orchestrator
 
+**Scroll policy**:
+The pure decision of what one throttled scroll frame does to the Media preview: on touch the bubble **follows** its source card (and committed playback stops once the card has fully left the viewport); on desktop any real scroll past a small jitter threshold dismisses committed playback; a hidden bubble detaches its tracking. Owns no DOM, `window`, or `matchMedia` — the singleton gathers the frame's facts as plain data, calls the policy (`previewScrollPolicy.ts`), and executes the commands it returns. The listener/rAF mechanics that decide *when* a frame happens belong to `scrollAnchor.ts`, not the policy. See [ADR-0004](docs/adr/0004-media-preview-decorative-singleton-card-is-control.md).
+_Avoid_: scroll handler, scroll listener (those are the mechanics), dismiss-on-scroll (that's only the desktop half)
+
 **Preview clip**:
 A short (~3s), silent, small-format excerpt cut from a full recording — the thing a video Media preview plays. Generated ahead of time from local source recordings; the full recording never ships.
 _Avoid_: video, trailer, thumbnail

--- a/v2-blog/src/_helpers/previewScrollPolicy.ts
+++ b/v2-blog/src/_helpers/previewScrollPolicy.ts
@@ -1,0 +1,76 @@
+/**
+ * Pure scroll-frame policy for the media-preview bubble (ADR 0004).
+ *
+ * Extracted from the `SharedMediaPreview` singleton so the per-frame scroll
+ * *decision* — touch anchored follow + stop-when-gone vs desktop
+ * dismiss-on-scroll — is testable without a DOM, a real `window`, or
+ * `matchMedia`. This module is a leaf: it never reads any of those. The
+ * singleton gathers the frame's facts (visibility, pointer mode, live source
+ * rect, scroll positions) into a {@link ScrollFrameInput}, and executes the
+ * commands returned back; `scrollAnchor.ts` owns the listener/rAF mechanics
+ * that decide *when* a frame happens at all.
+ */
+
+/**
+ * Desktop dismiss-on-scroll (ADR 0004): once committed playback is scrolled
+ * past this many pixels, it stops. A small threshold ignores trackpad jitter.
+ */
+export const DESKTOP_SCROLL_STOP_PX = 8;
+
+/** The vertical extent of the tracked source card — all the policy needs. */
+export interface SourceRectSlice {
+  top: number;
+  bottom: number;
+}
+
+/** Everything one throttled scroll frame gets to see, as plain data. */
+export interface ScrollFrameInput {
+  /** Whether the bubble is currently visible (Container's `is-visible`). */
+  visible: boolean;
+  /** Coarse pointer (touch): follow the card. Fine pointer: dismiss instead. */
+  coarsePointer: boolean;
+  /** True while playback is committed, not just a glimpse. */
+  committed: boolean;
+  /** Live rect of the tracked source card; null when nothing is tracked. */
+  sourceRect: SourceRectSlice | null;
+  viewportHeight: number;
+  scrollY: number;
+  /** Scroll position captured at desktop play time (the dismiss baseline). */
+  playStartScrollY: number;
+}
+
+/** Commands the singleton must execute; the policy never performs them itself. */
+export type ScrollFrameCommand =
+  /** The bubble is gone — detach the scroll tracking. */
+  | { type: 'stopTracking' }
+  /** Reposition the bubble onto its live source rect (touch follow). */
+  | { type: 'follow' }
+  /** Stop committed playback and collapse (scroll-out / dismiss). */
+  | { type: 'stop' };
+
+/**
+ * Decides what one throttled scroll frame does to the bubble. Touch: keep the
+ * bubble glued to its source card, and stop committed playback once the card
+ * has fully left the viewport (it still follows first, trailing off-screen).
+ * Desktop: any real scroll past the jitter threshold dismisses committed
+ * playback; glimpses are cursor-bound and never scroll-dismissed.
+ */
+export function decideScrollFrame(input: ScrollFrameInput): ScrollFrameCommand[] {
+  if (!input.visible) return [{ type: 'stopTracking' }];
+
+  if (input.coarsePointer) {
+    const rect = input.sourceRect;
+    if (!rect) return [];
+
+    const commands: ScrollFrameCommand[] = [{ type: 'follow' }];
+    const fullyGone = rect.bottom <= 0 || rect.top >= input.viewportHeight;
+    if (input.committed && fullyGone) commands.push({ type: 'stop' });
+    return commands;
+  }
+
+  const travelled = Math.abs(input.scrollY - input.playStartScrollY);
+  if (input.committed && travelled > DESKTOP_SCROLL_STOP_PX) {
+    return [{ type: 'stop' }];
+  }
+  return [];
+}

--- a/v2-blog/src/_helpers/sharedPreview.ts
+++ b/v2-blog/src/_helpers/sharedPreview.ts
@@ -16,15 +16,10 @@ import {
   INTENT_TICK_MS,
   LINGER_MS,
 } from './previewChoreography.ts';
+import { decideScrollFrame, type ScrollFrameCommand } from './previewScrollPolicy.ts';
 
 export type { PreviewPlacement } from './previewGeometry.ts';
 export type { MediaType, MediaKind } from './previewChoreography.ts';
-
-/**
- * Desktop dismiss-on-scroll (ADR 0004): once committed playback is scrolled
- * past this many pixels, it stops. A small threshold ignores trackpad jitter.
- */
-const DESKTOP_SCROLL_STOP_PX = 8;
 
 /**
  * Two sizes for the default round Face (ADR 0004/0006). The glimpse is the
@@ -446,34 +441,37 @@ export class SharedMediaPreview {
   }
 
   /**
-   * One throttled scroll frame. Touch: reposition the bubble to its card and
-   * stop committed playback once the card is fully off-screen. Desktop: dismiss
-   * committed playback once scrolled past the threshold.
+   * One throttled scroll frame: gathers the frame's facts (the only DOM/window
+   * reads), hands them to the pure scroll policy (`previewScrollPolicy.ts`),
+   * and executes the commands it returns — one real side effect per command.
    */
   private _onScrollFrame(): void {
-    if (!this._container.isVisible) {
-      this._stopTracking();
-      return;
-    }
+    const commands = decideScrollFrame({
+      visible: this._container.isVisible,
+      coarsePointer: this._coarsePointer(),
+      committed: this._choreography.isCommitted,
+      sourceRect: this._trackGetRect ? this._trackGetRect() : null,
+      viewportHeight: typeof window !== 'undefined' ? window.innerHeight : 0,
+      scrollY: this._scrollY(),
+      playStartScrollY: this._playStartScrollY,
+    });
+    this._executeScroll(commands);
+  }
 
-    if (this._coarsePointer()) {
-      if (this._trackGetRect) {
-        this._reposition();
-
-        // Committed playback ends when its source has fully left the viewport.
-        if (this._choreography.isCommitted) {
-          const rect = this._trackGetRect();
-          if (rect.bottom <= 0 || rect.top >= window.innerHeight) {
-            this.stop();
-          }
-        }
+  /** Executes the scroll policy's commands; the counterpart of `_execute`. */
+  private _executeScroll(commands: ScrollFrameCommand[]): void {
+    for (const command of commands) {
+      switch (command.type) {
+        case 'stopTracking':
+          this._stopTracking();
+          break;
+        case 'follow':
+          this._reposition();
+          break;
+        case 'stop':
+          this.stop();
+          break;
       }
-      return;
-    }
-
-    // Desktop: scrolling away from a playing preview dismisses it.
-    if (this._choreography.isCommitted && Math.abs(this._scrollY() - this._playStartScrollY) > DESKTOP_SCROLL_STOP_PX) {
-      this.stop();
     }
   }
 

--- a/v2-blog/tests/unit/helpers/previewScrollPolicy.test.ts
+++ b/v2-blog/tests/unit/helpers/previewScrollPolicy.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import {
+  decideScrollFrame,
+  DESKTOP_SCROLL_STOP_PX,
+  type ScrollFrameInput,
+} from "../../../src/_helpers/previewScrollPolicy.ts";
+
+/** A frame with quiet defaults; each case overrides only what it exercises. */
+function frame(over: Partial<ScrollFrameInput> = {}): ScrollFrameInput {
+  return {
+    visible: true,
+    coarsePointer: false,
+    committed: false,
+    sourceRect: null,
+    viewportHeight: 768,
+    scrollY: 0,
+    playStartScrollY: 0,
+    ...over,
+  };
+}
+
+describe("previewScrollPolicy — hidden bubble", () => {
+  it("detaches tracking when the bubble is no longer visible", () => {
+    expect(decideScrollFrame(frame({ visible: false }))).toEqual([{ type: "stopTracking" }]);
+  });
+
+  it("detaches even mid-playback on touch — nothing else runs on a hidden bubble", () => {
+    const input = frame({
+      visible: false,
+      coarsePointer: true,
+      committed: true,
+      sourceRect: { top: 100, bottom: 180 },
+    });
+    expect(decideScrollFrame(input)).toEqual([{ type: "stopTracking" }]);
+  });
+});
+
+describe("previewScrollPolicy — desktop dismiss-on-scroll (ADR 0004)", () => {
+  it("keeps playing within the jitter threshold", () => {
+    const input = frame({ committed: true, scrollY: 4, playStartScrollY: 0 });
+    expect(decideScrollFrame(input)).toEqual([]);
+  });
+
+  it("keeps playing at exactly the threshold — only real travel dismisses", () => {
+    const input = frame({ committed: true, scrollY: DESKTOP_SCROLL_STOP_PX, playStartScrollY: 0 });
+    expect(decideScrollFrame(input)).toEqual([]);
+  });
+
+  it("stops committed playback once scrolled past the threshold", () => {
+    const input = frame({ committed: true, scrollY: 40, playStartScrollY: 0 });
+    expect(decideScrollFrame(input)).toEqual([{ type: "stop" }]);
+  });
+
+  it("dismisses on upward scroll too — the threshold is a distance, not a direction", () => {
+    const input = frame({ committed: true, scrollY: 100, playStartScrollY: 200 });
+    expect(decideScrollFrame(input)).toEqual([{ type: "stop" }]);
+  });
+
+  it("never dismisses an uncommitted glimpse, however far the page scrolls", () => {
+    const input = frame({ committed: false, scrollY: 5000, playStartScrollY: 0 });
+    expect(decideScrollFrame(input)).toEqual([]);
+  });
+});
+
+describe("previewScrollPolicy — touch anchored follow (ADR 0004)", () => {
+  it("a tracked glimpse follows its source card", () => {
+    const input = frame({ coarsePointer: true, sourceRect: { top: 400, bottom: 440 } });
+    expect(decideScrollFrame(input)).toEqual([{ type: "follow" }]);
+  });
+
+  it("committed playback keeps following while the card is even partly visible", () => {
+    const input = frame({
+      coarsePointer: true,
+      committed: true,
+      sourceRect: { top: -30, bottom: 10 },
+    });
+    expect(decideScrollFrame(input)).toEqual([{ type: "follow" }]);
+  });
+
+  it("follows then stops once the card is fully above the viewport", () => {
+    const input = frame({
+      coarsePointer: true,
+      committed: true,
+      sourceRect: { top: -280, bottom: -200 },
+    });
+    expect(decideScrollFrame(input)).toEqual([{ type: "follow" }, { type: "stop" }]);
+  });
+
+  it("follows then stops once the card is fully below the viewport", () => {
+    const input = frame({
+      coarsePointer: true,
+      committed: true,
+      viewportHeight: 768,
+      sourceRect: { top: 768, bottom: 848 },
+    });
+    expect(decideScrollFrame(input)).toEqual([{ type: "follow" }, { type: "stop" }]);
+  });
+
+  it("a card grazing the top edge (bottom exactly 0) counts as gone", () => {
+    const input = frame({
+      coarsePointer: true,
+      committed: true,
+      sourceRect: { top: -80, bottom: 0 },
+    });
+    expect(decideScrollFrame(input)).toEqual([{ type: "follow" }, { type: "stop" }]);
+  });
+
+  it("an uncommitted glimpse trails its card off-screen without ever stopping", () => {
+    const input = frame({
+      coarsePointer: true,
+      committed: false,
+      sourceRect: { top: -280, bottom: -200 },
+    });
+    expect(decideScrollFrame(input)).toEqual([{ type: "follow" }]);
+  });
+
+  it("touch never uses the desktop scroll threshold", () => {
+    const input = frame({
+      coarsePointer: true,
+      committed: true,
+      sourceRect: { top: 300, bottom: 380 },
+      scrollY: 5000,
+      playStartScrollY: 0,
+    });
+    expect(decideScrollFrame(input)).toEqual([{ type: "follow" }]);
+  });
+
+  it("does nothing on touch when no source rect is tracked", () => {
+    const input = frame({ coarsePointer: true, committed: true, sourceRect: null });
+    expect(decideScrollFrame(input)).toEqual([]);
+  });
+});

--- a/v2-blog/tests/unit/helpers/sharedPreview.test.ts
+++ b/v2-blog/tests/unit/helpers/sharedPreview.test.ts
@@ -35,6 +35,30 @@ function trigger(src: string, over: Partial<PreviewTrigger> = {}): PreviewTrigge
   };
 }
 
+/**
+ * Replaces rAF with a manual queue and returns its flush, so a real window
+ * `scroll` event drives the ScrollAnchor's throttled frame deterministically
+ * — the public surface, no reaching into the singleton.
+ */
+function stubRaf(): () => void {
+  let cbs: Array<FrameRequestCallback | undefined> = [];
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => cbs.push(cb));
+  vi.stubGlobal("cancelAnimationFrame", (id: number) => {
+    cbs[id - 1] = undefined;
+  });
+  return () => {
+    const pending = cbs;
+    cbs = [];
+    pending.forEach((cb) => cb?.(0));
+  };
+}
+
+/** One user scroll: the window event plus the animation frame it schedules. */
+function scroll(flushRaf: () => void) {
+  window.dispatchEvent(new Event("scroll"));
+  flushRaf();
+}
+
 describe("sharedPreview", () => {
   beforeEach(() => {
     document.body.innerHTML = "";
@@ -46,6 +70,7 @@ describe("sharedPreview", () => {
   });
 
   afterEach(() => {
+    vi.unstubAllGlobals();
     vi.useRealTimers();
   });
 
@@ -540,6 +565,7 @@ describe("sharedPreview", () => {
   });
 
   it("desktop: dismisses committed playback once scrolled past the threshold", async () => {
+    const flushRaf = stubRaf();
     const { SharedMediaPreview } = await import("../../../src/_helpers/sharedPreview.ts");
     const preview = SharedMediaPreview.getInstance();
     const wrapper = document.querySelector<HTMLDivElement>("#mediaPreview");
@@ -556,12 +582,12 @@ describe("sharedPreview", () => {
 
     // A tiny jitter must not dismiss.
     Object.defineProperty(window, "scrollY", { configurable: true, value: 4 });
-    (preview as unknown as { _onScrollFrame(): void })._onScrollFrame();
+    scroll(flushRaf);
     expect(preview.isPlaying()).toBe(true);
 
     // Real scroll past the threshold dismisses.
     Object.defineProperty(window, "scrollY", { configurable: true, value: 40 });
-    (preview as unknown as { _onScrollFrame(): void })._onScrollFrame();
+    scroll(flushRaf);
     expect(preview.isPlaying()).toBe(false);
     expect(wrapper?.classList.contains("is-visible")).toBe(false);
     expect(pause).toHaveBeenCalled();
@@ -570,6 +596,7 @@ describe("sharedPreview", () => {
   });
 
   it("touch: stops committed playback when the source scrolls fully off-screen", async () => {
+    const flushRaf = stubRaf();
     const mm = vi.fn((q: string) => ({ matches: q.includes("hover: none") })) as unknown as typeof window.matchMedia;
     const prev = window.matchMedia;
     window.matchMedia = mm;
@@ -590,12 +617,12 @@ describe("sharedPreview", () => {
 
       // Still partly visible → keeps playing.
       rect = new DOMRect(0, 10, 300, 80);
-      (preview as unknown as { _onScrollFrame(): void })._onScrollFrame();
+      scroll(flushRaf);
       expect(preview.isPlaying()).toBe(true);
 
       // Fully above the viewport → stop.
       rect = new DOMRect(0, -200, 300, 80);
-      (preview as unknown as { _onScrollFrame(): void })._onScrollFrame();
+      scroll(flushRaf);
       expect(preview.isPlaying()).toBe(false);
       expect(pause).toHaveBeenCalled();
     } finally {
@@ -604,6 +631,7 @@ describe("sharedPreview", () => {
   });
 
   it("touch: a tracked glimpse trails its source past the top edge (vertical unclamped)", async () => {
+    const flushRaf = stubRaf();
     const mm = vi.fn((q: string) => ({ matches: q.includes("hover: none") })) as unknown as typeof window.matchMedia;
     const prev = window.matchMedia;
     window.matchMedia = mm;
@@ -621,7 +649,7 @@ describe("sharedPreview", () => {
 
       // Card scrolled above the viewport: y follows it negative, not pinned.
       rect = new DOMRect(0, -100, 300, 40);
-      (preview as unknown as { _onScrollFrame(): void })._onScrollFrame();
+      scroll(flushRaf);
 
       // right placement, glimpse h=100: eixoY = -100 + (40 - 100) / 2 = -130.
       expect(wrapper?.style.getPropertyValue("--preview-y")).toBe("-130px");


### PR DESCRIPTION
## What

Extracts the media-preview scroll decision out of the `SharedMediaPreview` singleton into a pure module, `src/_helpers/previewScrollPolicy.ts` — same pattern as the Choreography extraction (ADR-0006 direction, ADR-0004 semantics):

- `decideScrollFrame(input): ScrollFrameCommand[]` maps one throttled scroll frame's facts (visibility, pointer mode, committed state, live source rect, scroll positions) to commands: `stopTracking` | `follow` | `stop`. No DOM, `window`, or `matchMedia` inside.
- The singleton's `_onScrollFrame` is now pure wiring: gather facts, call the policy, execute commands via `_executeScroll` (counterpart of the existing `_execute`).
- `DESKTOP_SCROLL_STOP_PX` moves into the policy module. `scrollAnchor.ts` keeps the listener/rAF mechanics — the split is *when a frame happens* vs *what it does*.
- CONTEXT.md gains a **Scroll policy** glossary entry.

## Why

The interface wasn't the test surface: five test sites reached the behavior by casting `(preview as unknown as { _onScrollFrame(): void })._onScrollFrame()`. All five are gone — policy behavior now has its own interface suite (`previewScrollPolicy.test.ts`, 15 tests), and the remaining sharedPreview scroll tests drive real `window` scroll events through a manual-rAF stub (same pattern as `scrollAnchor.test.ts`).

The extraction also locked behaviors the old tests never covered: hidden-bubble detach, follow-before-stop ordering on touch scroll-out, the strict `> 8px` desktop threshold (distance, so upward scroll dismisses too), inclusive edge-grazing bounds, touch no-op without a tracked rect.

## Verification

- `npm run check` green: typecheck + eslint + stylelint + vitest, 338 tests (323 → 338).
- `grep -rn "_onScrollFrame" tests/` returns nothing.
