### PR TITLE
feat: implement ls, grep and cat as shared terminal Commands

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -13,7 +13,7 @@ A named, pre-registered handler the Terminal can run (e.g. `help`, `list`, `open
 _Avoid_: program, process
 
 **Shared Command**:
-A Command whose semantics are site-wide — it must behave identically on every Terminal surface (`theme`, `whoami`). Shared Commands come from one registry factory (`_helpers/terminal/commands.ts`) that each surface spreads into its own registry; a surface may wrap presentation (flavor text) but never semantics. Commands that are not shared are **surface Commands** (`exit`, `skip`, the cheats) and stay owned by their surface.
+A Command whose semantics are site-wide — it must behave identically on every Terminal surface (`theme`, `whoami`, `ls`, `grep`, `cat`). Shared Commands come from one registry factory (`_helpers/terminal/commands.ts`) that each surface spreads into its own registry; a surface may wrap presentation (flavor text) but never semantics. Commands that are not shared are **surface Commands** (`exit`, `skip`, `clear`, the cheats) and stay owned by their surface.
 _Avoid_: global command, common command, built-in
 
 **Summon**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -13,7 +13,7 @@ A named, pre-registered handler the Terminal can run (e.g. `help`, `list`, `open
 _Avoid_: program, process
 
 **Shared Command**:
-A Command whose semantics are site-wide — it must behave identically on every Terminal surface (`theme`, `whoami`, `ls`, `grep`, `cat`). Shared Commands come from one registry factory (`_helpers/terminal/commands.ts`) that each surface spreads into its own registry; a surface may wrap presentation (flavor text) but never semantics. Commands that are not shared are **surface Commands** (`exit`, `skip`, `clear`, the cheats) and stay owned by their surface.
+A Command whose semantics are site-wide — it must behave identically on every Terminal surface (`theme`, `whoami`, `ls`, `grep`, `cat`, `random`). Shared Commands come from one registry factory (`_helpers/terminal/commands.ts`) that each surface spreads into its own registry; a surface may wrap presentation (flavor text) but never semantics. Commands that are not shared are **surface Commands** (`exit`, `skip`, `clear`, the cheats) and stay owned by their surface.
 _Avoid_: global command, common command, built-in
 
 **Summon**:

--- a/v2-blog/src/_helpers/terminal/commands.ts
+++ b/v2-blog/src/_helpers/terminal/commands.ts
@@ -3,22 +3,35 @@
  * site-wide and must behave identically on every Terminal surface. Each
  * surface spreads the factory's registry into its own and may wrap
  * presentation (whoami flavor) but never semantics — the books shell and the
- * summoned overlay both get their `theme` / `whoami` from here, so the two
- * can never diverge again.
+ * summoned overlay both get their `theme` / `whoami` / `ls` / `grep` / `cat`
+ * from here, so the two can never diverge again.
  */
 
 import { getTheme, setTheme, type Theme } from "../theme.ts";
 import { getIdentity } from "../identity.ts";
 import { CommandType, type CommandHandler } from "./core.ts";
 import type { ParsedCommand } from "./parser.ts";
+import type { Block } from "./blocks.ts";
+import {
+  buildTree,
+  fetchSiteIndex,
+  findNode,
+  renderSubtree,
+  rootListingBlock,
+  sanitizeNavQuery,
+  searchEntries,
+  type TreeNode,
+} from "./site-index.ts";
 
 /**
  * The narrow io a shared Command needs from its surface: the surface's own
- * way of writing log lines (bound to its TerminalCore).
+ * ways of writing output (bound to its TerminalCore).
  */
 export type CommandIo = {
   /** Writes a log line; same contract as `TerminalCore.append`. */
   append: (text: string, duration?: number, kind?: CommandType) => Promise<void>;
+  /** Renders a structured block; same contract as `TerminalCore.render`. */
+  render: (block: Block) => Promise<void>;
 };
 
 export type SharedCommandOptions = {
@@ -73,5 +86,97 @@ export function createSharedCommands(
       // Read fresh each run so it reflects a name chosen on another surface.
       await io.append(whoamiFlavor(getIdentity()), 0.2, CommandType.info);
     },
+
+    // `ls [target]` — browse the site tree: bare → the root listing block,
+    // a folder → its `tree`-style subtree, a leaf → its title + description.
+    ls: async (ctx: ParsedCommand): Promise<void> => {
+      await io.append(ctx.raw, 0.2, CommandType.command);
+
+      const root = buildTree(await fetchSiteIndex());
+      const target = sanitizeNavQuery(ctx.positionals[0] ?? "");
+
+      if (!target) {
+        await io.render(rootListingBlock(root));
+        return;
+      }
+
+      const node = findNode(root, target);
+      if (!node) {
+        await io.append(`ls: ${target}: no such page`, 0.2, CommandType.error);
+        return;
+      }
+
+      if (node.children.length > 0) {
+        for (const line of renderSubtree(node)) {
+          await io.append(line, 0.02, CommandType.log);
+        }
+        return;
+      }
+
+      await printLeaf(io, node);
+    },
+
+    // `grep <term>` — search page titles and descriptions across the site
+    // index; matches render as a linked listing.
+    grep: async (ctx: ParsedCommand): Promise<void> => {
+      await io.append(ctx.raw, 0.2, CommandType.command);
+
+      const term = ctx.positionals.join(" ").trim().toLowerCase().slice(0, 64);
+      if (!term) {
+        await io.append("usage: grep <term>", 0.2, CommandType.info);
+        return;
+      }
+
+      const matches = searchEntries(await fetchSiteIndex(), term);
+      if (matches.length === 0) {
+        await io.append(`grep: no matches for "${term}"`, 0.2, CommandType.error);
+        return;
+      }
+
+      await io.render({
+        type: "section",
+        title: `grep "${term}" — ${matches.length} match${matches.length === 1 ? "" : "es"}`,
+        tone: "surface",
+        body: [
+          {
+            type: "columns",
+            rows: matches.map((entry) => [
+              { text: entry.title, href: entry.url },
+              { text: entry.section, tone: "muted", align: "end" },
+            ]),
+          },
+        ],
+      });
+    },
+
+    // `cat <page>` — print a page's title and description; folders belong to `ls`.
+    cat: async (ctx: ParsedCommand): Promise<void> => {
+      await io.append(ctx.raw, 0.2, CommandType.command);
+
+      const target = sanitizeNavQuery(ctx.positionals[0] ?? "");
+      if (!target) {
+        await io.append("usage: cat <page>", 0.2, CommandType.info);
+        return;
+      }
+
+      const node = findNode(buildTree(await fetchSiteIndex()), target);
+      if (!node) {
+        await io.append(`cat: ${target}: no such page`, 0.2, CommandType.error);
+        return;
+      }
+
+      if (node.children.length > 0) {
+        await io.append(`cat: ${target}: is a folder — try: ls ${target}`, 0.2, CommandType.error);
+        return;
+      }
+
+      await printLeaf(io, node);
+    },
   };
+}
+
+/** Prints a leaf page uniformly: its title line, then its description. */
+async function printLeaf(io: CommandIo, node: TreeNode): Promise<void> {
+  await io.append(node.title ?? node.name, 0.2, CommandType.title);
+  await io.append(node.description ?? "(no description)", 0.2, CommandType.logdata);
 }

--- a/v2-blog/src/_helpers/terminal/commands.ts
+++ b/v2-blog/src/_helpers/terminal/commands.ts
@@ -14,6 +14,7 @@ import type { ParsedCommand } from "./parser.ts";
 import type { Block } from "./blocks.ts";
 import {
   buildTree,
+  collectPages,
   fetchSiteIndex,
   findNode,
   renderSubtree,
@@ -32,6 +33,8 @@ export type CommandIo = {
   append: (text: string, duration?: number, kind?: CommandType) => Promise<void>;
   /** Renders a structured block; same contract as `TerminalCore.render`. */
   render: (block: Block) => Promise<void>;
+  /** Navigates to a site-internal URL (the surface owns how). */
+  navigate: (url: string) => void;
 };
 
 export type SharedCommandOptions = {
@@ -147,6 +150,34 @@ export function createSharedCommands(
           },
         ],
       });
+    },
+
+    // `random [folder]` — rolls a random page (site-wide, or scoped to a
+    // folder: `random books`, `random blog`) and navigates to it.
+    random: async (ctx: ParsedCommand): Promise<void> => {
+      await io.append(ctx.raw, 0.2, CommandType.command);
+
+      const root = buildTree(await fetchSiteIndex());
+      const target = sanitizeNavQuery(ctx.positionals[0] ?? "");
+
+      let scope: TreeNode | undefined = root;
+      if (target) {
+        scope = findNode(root, target);
+        if (!scope) {
+          await io.append(`random: ${target}: no such folder`, 0.2, CommandType.error);
+          return;
+        }
+      }
+
+      const pages = collectPages(scope);
+      if (pages.length === 0) {
+        await io.append(`random: nothing to roll in ${target || "~"}`, 0.2, CommandType.error);
+        return;
+      }
+
+      const pick = pages[Math.floor(Math.random() * pages.length)];
+      await io.append(`rolling the dice... ${pick.title ?? pick.name}`, 0.2, CommandType.status);
+      io.navigate(pick.url!);
     },
 
     // `cat <page>` — print a page's title and description; folders belong to `ls`.

--- a/v2-blog/src/_helpers/terminal/site-index.ts
+++ b/v2-blog/src/_helpers/terminal/site-index.ts
@@ -283,6 +283,25 @@ export function matchEntry(entries: SiteIndexEntry[], query: string): MatchResul
 }
 
 /**
+ * Case-insensitive substring search over entry titles and descriptions
+ * (the `grep` Command's engine). A blank term matches nothing.
+ *
+ * @param entries - The site index.
+ * @param term - The user's search term.
+ * @returns The matching entries, in index order.
+ */
+export function searchEntries(entries: SiteIndexEntry[], term: string): SiteIndexEntry[] {
+  const needle = term.trim().toLowerCase();
+  if (!needle) return [];
+
+  return entries.filter(
+    (entry) =>
+      entry.title.toLowerCase().includes(needle) ||
+      (entry.description ?? "").toLowerCase().includes(needle)
+  );
+}
+
+/**
  * Lazily fetches and parses the site index, caching it for the page load.
  * Coalesces concurrent calls; a failed fetch resolves to `[]` and is retryable.
  *

--- a/v2-blog/src/_helpers/terminal/site-index.ts
+++ b/v2-blog/src/_helpers/terminal/site-index.ts
@@ -283,6 +283,23 @@ export function matchEntry(entries: SiteIndexEntry[], query: string): MatchResul
 }
 
 /**
+ * Gathers every descendant of `node` that carries a page url (the `random`
+ * Command's pool). The node itself is excluded — `random books` rolls a book,
+ * never the books listing page.
+ *
+ * @param node - The subtree to collect from.
+ * @returns The descendant nodes that are real pages, in DFS order.
+ */
+export function collectPages(node: TreeNode): TreeNode[] {
+  const pages: TreeNode[] = [];
+  for (const child of node.children) {
+    if (child.url) pages.push(child);
+    pages.push(...collectPages(child));
+  }
+  return pages;
+}
+
+/**
  * Case-insensitive substring search over entry titles and descriptions
  * (the `grep` Command's engine). A blank term matches nothing.
  *

--- a/v2-blog/src/components/terminal-overlay.ts
+++ b/v2-blog/src/components/terminal-overlay.ts
@@ -380,13 +380,14 @@ export class TerminalOverlay extends LitElement {
   /** Per-tab command-history store (survives full-page navigations). */
   private _session = new TerminalSession();
 
-  // Shared Commands (theme, whoami, ls, grep, cat) — semantics owned by the
-  // factory so this surface and the books shell can never diverge. Declared
-  // before _core so the registry below can alias into it; the io closures
-  // resolve this._core lazily.
+  // Shared Commands (theme, whoami, ls, grep, cat, random) — semantics owned
+  // by the factory so this surface and the books shell can never diverge.
+  // Declared before _core so the registry below can alias into it; the io
+  // closures resolve this._core lazily.
   private _shared = createSharedCommands({
     append: (text, duration, kind) => this._core.append(text, duration, kind),
     render: (block) => this._core.render(block),
+    navigate: (url) => this._navigateTo(url),
   });
 
   private _core: TerminalCore = new TerminalCore({
@@ -394,7 +395,7 @@ export class TerminalOverlay extends LitElement {
       help: async (ctx: ParsedCommand) => {
         await this._core.append(ctx.raw, 0.2, CommandType.command);
         await this._core.append(
-          "help - list commands\nls [folder] - browse the site tree (blog, books, …)\ngrep <term> - search pages\ncat <page> - peek at a page\nopen <slug> - go to a page\ntheme [dark|pinky] - switch the theme\nwhoami - who are you, really\nexit / q - close the terminal",
+          "help - list commands\nls [folder] - browse the site tree (blog, books, …)\ngrep <term> - search pages\ncat <page> - peek at a page\nopen <slug> - go to a page\nrandom [folder] - roll a page and go\ntheme [dark|pinky] - switch the theme\nwhoami - who are you, really\nexit / q - close the terminal",
           0.3,
           CommandType.logdata
         );
@@ -431,7 +432,7 @@ export class TerminalOverlay extends LitElement {
         switch (result.kind) {
           case "navigate":
             await this._core.append(`opening ${result.title}...`, 0.2, CommandType.status);
-            window.location.href = result.url;
+            this._navigateTo(result.url);
             break;
           case "ambiguous":
             await this._core.append(`"${query}" is ambiguous — did you mean:`, 0.2, CommandType.error);
@@ -453,6 +454,11 @@ export class TerminalOverlay extends LitElement {
     skipAnimations: () => this._skipAnimations,
     onLineWritten: () => this._scrollToBottom(),
   });
+
+  /** Full-page navigation to a site-internal URL (spy seam for tests). */
+  private _navigateTo(url: string): void {
+    window.location.href = url;
+  }
 
   /**
    * Closes the terminal in response to the `exit` / `q` command.

--- a/v2-blog/src/components/terminal-overlay.ts
+++ b/v2-blog/src/components/terminal-overlay.ts
@@ -6,9 +6,6 @@ import type { ParsedCommand } from "../_helpers/terminal/parser.ts";
 import {
   buildTree,
   fetchSiteIndex,
-  findNode,
-  rootListingBlock,
-  renderSubtree,
   resolveOpen,
   sanitizeNavQuery,
 } from "../_helpers/terminal/site-index.ts";
@@ -383,29 +380,33 @@ export class TerminalOverlay extends LitElement {
   /** Per-tab command-history store (survives full-page navigations). */
   private _session = new TerminalSession();
 
+  // Shared Commands (theme, whoami, ls, grep, cat) — semantics owned by the
+  // factory so this surface and the books shell can never diverge. Declared
+  // before _core so the registry below can alias into it; the io closures
+  // resolve this._core lazily.
+  private _shared = createSharedCommands({
+    append: (text, duration, kind) => this._core.append(text, duration, kind),
+    render: (block) => this._core.render(block),
+  });
+
   private _core: TerminalCore = new TerminalCore({
     commands: {
       help: async (ctx: ParsedCommand) => {
         await this._core.append(ctx.raw, 0.2, CommandType.command);
         await this._core.append(
-          "help - list commands\nls [folder] - browse the site tree (blog, books, …)\nopen <slug> - go to a page\ntheme [dark|pinky] - switch the theme\nwhoami - who are you, really\nexit / q - close the terminal",
+          "help - list commands\nls [folder] - browse the site tree (blog, books, …)\ngrep <term> - search pages\ncat <page> - peek at a page\nopen <slug> - go to a page\ntheme [dark|pinky] - switch the theme\nwhoami - who are you, really\nexit / q - close the terminal",
           0.3,
           CommandType.logdata
         );
         await this._core.append("psst — this is a cheat console. the classics still work.", 0.2, CommandType.info);
       },
 
-      ls: async (ctx: ParsedCommand) => this._listContent(ctx),
-      list: async (ctx: ParsedCommand) => this._listContent(ctx),
+      list: async (ctx: ParsedCommand) => this._shared.ls(ctx),
 
       exit: async (ctx: ParsedCommand) => this._exit(ctx),
       q: async (ctx: ParsedCommand) => this._exit(ctx),
 
-      // Shared Commands (theme, whoami) — semantics owned by the factory so
-      // this surface and the books shell can never diverge.
-      ...createSharedCommands({
-        append: (text, duration, kind) => this._core.append(text, duration, kind),
-      }),
+      ...this._shared,
 
       rosebud: async (ctx: ParsedCommand) => {
         await this._core.append(ctx.raw, 0.2, CommandType.command);
@@ -486,45 +487,6 @@ export class TerminalOverlay extends LitElement {
   private _onOpened(): void {
     if (takeFirstBootOfSession()) void this._boot();
     playFirstSummonChime();
-  }
-
-  /**
-   * Handles `ls [target]` against the site tree:
-   * - no arg → the top level (folders with counts, then leaf pages);
-   * - a folder → its `tree`-style subtree;
-   * - a leaf → its title and description.
-   *
-   * @param ctx - The parsed command (first positional is an optional target).
-   * @returns A promise that settles once the output is written.
-   */
-  private async _listContent(ctx: ParsedCommand): Promise<void> {
-    await this._core.append(ctx.raw, 0.2, CommandType.command);
-
-    const root = buildTree(await fetchSiteIndex());
-    const target = sanitizeNavQuery(ctx.positionals[0] ?? "");
-
-    if (!target) {
-      // Structured: a tinted section with an aligned two-column grid.
-      await this._core.render(rootListingBlock(root));
-      return;
-    }
-
-    const node = findNode(root, target);
-    if (!node) {
-      await this._core.append(`ls: ${target}: no such page`, 0.2, CommandType.error);
-      return;
-    }
-
-    if (node.children.length > 0) {
-      for (const line of renderSubtree(node)) {
-        await this._core.append(line, 0.02, CommandType.log);
-      }
-      return;
-    }
-
-    // Leaf page: show its title and description (uniform).
-    await this._core.append(node.title ?? node.name, 0.2, CommandType.title);
-    await this._core.append(node.description ?? "(no description)", 0.2, CommandType.logdata);
   }
 
   async firstUpdated() {

--- a/v2-blog/src/components/terminal-shell.ts
+++ b/v2-blog/src/components/terminal-shell.ts
@@ -82,7 +82,7 @@ export class TerminalShell extends LitElement {
           this.dispatch({ type: "SIDEBAR_SET", open: true });
         } else {
           await this.appendToLog(
-            "help · list · open <id> · theme · whoami υ.υ",
+            "help · list · open <id> · ls · grep <term> · cat <page> · theme · whoami · clear υ.υ",
             0.5,
             CommandType.info
           )
@@ -135,11 +135,14 @@ export class TerminalShell extends LitElement {
 
       book: async (ctx) => this.COMMANDS.open(ctx),
 
-      // Shared Commands (theme, whoami) — semantics owned by the factory so
-      // this surface and the summoned overlay can never diverge. Only the
-      // whoami flavor line is books-specific.
+      // Shared Commands (theme, whoami, ls, grep, cat) — semantics owned by
+      // the factory so this surface and the summoned overlay can never
+      // diverge. Only the whoami flavor line is books-specific.
       ...createSharedCommands(
-        { append: (text, duration, kind) => this.appendToLog(text, duration ?? 0.2, kind ?? CommandType.log) },
+        {
+          append: (text, duration, kind) => this.appendToLog(text, duration ?? 0.2, kind ?? CommandType.log),
+          render: (block) => this._core.render(block),
+        },
         { whoamiFlavor: (id) => `you are ${id} — guest of book_os υ.υ` }
       ),
 
@@ -157,37 +160,15 @@ export class TerminalShell extends LitElement {
         }
       },
 
-      // list portfolio branchs/commits and more
-      // just like git but without the write permission
-      git: async (ctx) => {
-        await this.appendToLog(`${ctx.raw}`, 0.2, CommandType.command);
-
-      },
-
-      // list terminal archives
-      ls: async (ctx) => {
-        await this.appendToLog(`${ctx.raw}`, 0.2, CommandType.command);
-
-      },
-
-      // search posts, files 
-      grep: async (ctx) => {
-        await this.appendToLog(`${ctx.raw}`, 0.2, CommandType.command);
-
-      },
-
-      // display contents only no flags 
-      cat: async (ctx) => {
-        await this.appendToLog(`${ctx.raw}`, 0.2, CommandType.command);
-
-      },
-
       clear: async (ctx) => {
         await this.appendToLog(`${ctx.raw}`, 0.2, CommandType.command);
-        // Todo: improve clear
-        // this._clearOutput();
-        // await this.appendToLog("SCREEN CLEARED.", 0.05, CommandType.log);
+        this._clearOutput();
       },
+
+      cls: async (ctx) => this.COMMANDS.clear(ctx),
+      c: async (ctx) => this.COMMANDS.clear(ctx),
+
+      l: async (ctx) => this.COMMANDS.list(ctx),
     };
 
   // Declared after COMMANDS so the initializer can hand it to the core.

--- a/v2-blog/src/components/terminal-shell.ts
+++ b/v2-blog/src/components/terminal-shell.ts
@@ -82,7 +82,7 @@ export class TerminalShell extends LitElement {
           this.dispatch({ type: "SIDEBAR_SET", open: true });
         } else {
           await this.appendToLog(
-            "help · list · open <id> · ls · grep <term> · cat <page> · theme · whoami · clear υ.υ",
+            "help · list · open <id> · random · ls · grep <term> · cat <page> · theme · whoami · clear υ.υ",
             0.5,
             CommandType.info
           )
@@ -158,6 +158,22 @@ export class TerminalShell extends LitElement {
         } else {
           await this.appendToLog(ctx.raw, 0.2, CommandType.command);
         }
+      },
+
+      // picks a random book and opens it (the sidebar's "random book" button)
+      random: async (ctx) => {
+        await this.appendToLog(`${ctx.raw}`, 0, CommandType.command);
+
+        this._ensureBookDataLoaded();
+        const books = this.bookData.filter((b) => b.url);
+        if (books.length === 0) {
+          await this.appendToLog("no books to pick from >.<", 0.05, CommandType.error);
+          return;
+        }
+
+        const book = books[Math.floor(Math.random() * books.length)];
+        await this.appendToLog(`rolling the dice... [${book.id}] ${book.title}`, 0.05, CommandType.status);
+        this._navigateTo(book.url!);
       },
 
       clear: async (ctx) => {

--- a/v2-blog/src/components/terminal-shell.ts
+++ b/v2-blog/src/components/terminal-shell.ts
@@ -135,13 +135,14 @@ export class TerminalShell extends LitElement {
 
       book: async (ctx) => this.COMMANDS.open(ctx),
 
-      // Shared Commands (theme, whoami, ls, grep, cat) — semantics owned by
-      // the factory so this surface and the summoned overlay can never
-      // diverge. Only the whoami flavor line is books-specific.
+      // Shared Commands (theme, whoami, ls, grep, cat, random) — semantics
+      // owned by the factory so this surface and the summoned overlay can
+      // never diverge. Only the whoami flavor line is books-specific.
       ...createSharedCommands(
         {
           append: (text, duration, kind) => this.appendToLog(text, duration ?? 0.2, kind ?? CommandType.log),
           render: (block) => this._core.render(block),
+          navigate: (url) => this._navigateTo(url),
         },
         { whoamiFlavor: (id) => `you are ${id} — guest of book_os υ.υ` }
       ),
@@ -158,22 +159,6 @@ export class TerminalShell extends LitElement {
         } else {
           await this.appendToLog(ctx.raw, 0.2, CommandType.command);
         }
-      },
-
-      // picks a random book and opens it (the sidebar's "random book" button)
-      random: async (ctx) => {
-        await this.appendToLog(`${ctx.raw}`, 0, CommandType.command);
-
-        this._ensureBookDataLoaded();
-        const books = this.bookData.filter((b) => b.url);
-        if (books.length === 0) {
-          await this.appendToLog("no books to pick from >.<", 0.05, CommandType.error);
-          return;
-        }
-
-        const book = books[Math.floor(Math.random() * books.length)];
-        await this.appendToLog(`rolling the dice... [${book.id}] ${book.title}`, 0.05, CommandType.status);
-        this._navigateTo(book.url!);
       },
 
       clear: async (ctx) => {
@@ -927,7 +912,7 @@ export class TerminalShell extends LitElement {
               <span> - clear the console</span>
             </p>
             <p class="info item">
-              <button type="button" class="btn mobile" @click=${() => this._onQuickAction("random")}>random book</button>
+              <button type="button" class="btn mobile" @click=${() => this._onQuickAction("random books")}>random book</button>
               <span> - get a random book to be analized</span>
             </p>
           </div>

--- a/v2-blog/tests/unit/components/terminal-overlay.test.ts
+++ b/v2-blog/tests/unit/components/terminal-overlay.test.ts
@@ -37,7 +37,9 @@ function submit(el: TerminalOverlay, value: string) {
 }
 
 async function flush() {
-  for (let i = 0; i < 12; i++) await Promise.resolve();
+  // Generous microtask budget: a command's appends resolve one line per tick
+  // (plus any interleaved boot-flavour lines and the site-index fetch).
+  for (let i = 0; i < 40; i++) await Promise.resolve();
 }
 
 beforeEach(() => {
@@ -229,6 +231,29 @@ describe("terminal-overlay", () => {
       submit(el, "theme light");
       await flush();
       expect(localStorage.getItem("theme")).toBe("pinky");
+    });
+
+    // Drift guard: ls is a shared Command — this surface renders the same
+    // site-tree listing as the books shell (see _helpers/terminal/commands.ts).
+    it("ls renders the shared site-tree listing (shared Command contract)", async () => {
+      const el = await mountOverlay();
+      el.open = true;
+      await el.updateComplete;
+
+      vi.spyOn(globalThis, "fetch").mockResolvedValue({
+        ok: true,
+        json: async () => [
+          { section: "pages", title: "About me", url: "/about/", description: "Who I am" },
+        ],
+      } as Response);
+
+      submit(el, "ls");
+      await flush();
+
+      const section = $(el, "#overlay-log .terminal-section")!;
+      expect(section).not.toBeNull();
+      expect(section.textContent).toContain("~/book_os");
+      expect(section.textContent).toContain("about");
     });
 
     it("whoami prints the generated identity", async () => {

--- a/v2-blog/tests/unit/components/terminal-shell.test.ts
+++ b/v2-blog/tests/unit/components/terminal-shell.test.ts
@@ -420,7 +420,7 @@ describe("terminal-shell startup phases", () => {
 
     const info = element.querySelector("#boot-log p.terminal-msg.info")!;
     expect(info.textContent).toBe(
-      "help · list · open <id> · ls · grep <term> · cat <page> · theme · whoami · clear υ.υ"
+      "help · list · open <id> · random · ls · grep <term> · cat <page> · theme · whoami · clear υ.υ"
     );
   });
 
@@ -464,6 +464,19 @@ describe("terminal-shell startup phases", () => {
     await (element as any)._executeCommand("c");
 
     expect(element.querySelector("#boot-log p.terminal-msg.error")).toBeNull();
+  });
+
+  it("random opens a randomly picked book (the sidebar button's command)", async () => {
+    const element = mountTerminalShell(listingMarkup());
+    await element.updateComplete;
+
+    const navSpy = vi.spyOn(element as any, "_navigateTo").mockImplementation(() => undefined);
+
+    await (element as any)._executeCommand("random");
+
+    expect(element.querySelector("#boot-log p.terminal-msg.status")?.textContent)
+      .toBe("rolling the dice... [012] A seca");
+    expect(navSpy).toHaveBeenCalledWith("/books/a-seca/");
   });
 
   it("git is no longer a command", async () => {

--- a/v2-blog/tests/unit/components/terminal-shell.test.ts
+++ b/v2-blog/tests/unit/components/terminal-shell.test.ts
@@ -419,7 +419,61 @@ describe("terminal-shell startup phases", () => {
     await (element as any)._executeCommand("help");
 
     const info = element.querySelector("#boot-log p.terminal-msg.info")!;
-    expect(info.textContent).toBe("help · list · open <id> · theme · whoami υ.υ");
+    expect(info.textContent).toBe(
+      "help · list · open <id> · ls · grep <term> · cat <page> · theme · whoami · clear υ.υ"
+    );
+  });
+
+  // Drift guard: ls is a shared Command — this surface renders the same
+  // site-tree listing as the overlay (see _helpers/terminal/commands.ts).
+  it("ls renders the shared site-tree listing (shared Command contract)", async () => {
+    const element = mountTerminalShell(listingMarkup());
+    await element.updateComplete;
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => [
+        { section: "pages", title: "About me", url: "/about/", description: "Who I am" },
+      ],
+    } as Response);
+
+    await (element as any)._executeCommand("ls");
+
+    const section = element.querySelector("#boot-log .terminal-section")!;
+    expect(section).not.toBeNull();
+    expect(section.textContent).toContain("~/book_os");
+    expect(section.textContent).toContain("about");
+  });
+
+  it("clear pushes the scrollback out of view instead of erroring", async () => {
+    const element = mountTerminalShell(listingMarkup());
+    await element.updateComplete;
+
+    await (element as any)._executeCommand("clear");
+
+    expect(element.querySelector("#boot-log p.terminal-msg.error")).toBeNull();
+    const bootLog = element.querySelector("#boot-log") as HTMLElement;
+    expect(bootLog.style.height).not.toBe("");
+  });
+
+  it("cls and c stay as aliases of clear", async () => {
+    const element = mountTerminalShell(listingMarkup());
+    await element.updateComplete;
+
+    await (element as any)._executeCommand("cls");
+    await (element as any)._executeCommand("c");
+
+    expect(element.querySelector("#boot-log p.terminal-msg.error")).toBeNull();
+  });
+
+  it("git is no longer a command", async () => {
+    const element = mountTerminalShell(listingMarkup());
+    await element.updateComplete;
+
+    await (element as any)._executeCommand("git status");
+
+    expect(element.querySelector("#boot-log p.terminal-msg.error")?.textContent)
+      .toBe("command not recognized: git status >.<");
   });
 
   it("ends the final batch with the open-a-card hint", async () => {

--- a/v2-blog/tests/unit/components/terminal-shell.test.ts
+++ b/v2-blog/tests/unit/components/terminal-shell.test.ts
@@ -434,6 +434,7 @@ describe("terminal-shell startup phases", () => {
       ok: true,
       json: async () => [
         { section: "pages", title: "About me", url: "/about/", description: "Who I am" },
+        { section: "books", title: "A seca", url: "/books/a-seca/", description: "Harper" },
       ],
     } as Response);
 
@@ -466,16 +467,26 @@ describe("terminal-shell startup phases", () => {
     expect(element.querySelector("#boot-log p.terminal-msg.error")).toBeNull();
   });
 
-  it("random opens a randomly picked book (the sidebar button's command)", async () => {
+  // Drift guard: random is a shared Command — `random books` (the sidebar
+  // button's command) rolls a book page from the same site index everywhere.
+  it("random books opens a random book (shared Command contract)", async () => {
     const element = mountTerminalShell(listingMarkup());
     await element.updateComplete;
 
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => [
+        { section: "pages", title: "About me", url: "/about/", description: "Who I am" },
+        { section: "books", title: "A seca", url: "/books/a-seca/", description: "Harper" },
+      ],
+    } as Response);
+    vi.spyOn(Math, "random").mockReturnValue(0);
     const navSpy = vi.spyOn(element as any, "_navigateTo").mockImplementation(() => undefined);
 
-    await (element as any)._executeCommand("random");
+    await (element as any)._executeCommand("random books");
 
     expect(element.querySelector("#boot-log p.terminal-msg.status")?.textContent)
-      .toBe("rolling the dice... [012] A seca");
+      .toBe("rolling the dice... A seca");
     expect(navSpy).toHaveBeenCalledWith("/books/a-seca/");
   });
 

--- a/v2-blog/tests/unit/helpers/terminal/commands.test.ts
+++ b/v2-blog/tests/unit/helpers/terminal/commands.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const gsapMock = vi.hoisted(() => ({
   to: vi.fn(),
@@ -39,15 +39,20 @@ type Line = { text: string; kind: CommandType | undefined };
 function makeIo() {
   const lines: Line[] = [];
   const blocks: Block[] = [];
+  const navs: string[] = [];
   return {
     lines,
     blocks,
+    navs,
     io: {
       append: async (text: string, _duration?: number, kind?: CommandType) => {
         lines.push({ text, kind });
       },
       render: async (block: Block) => {
         blocks.push(block);
+      },
+      navigate: (url: string) => {
+        navs.push(url);
       },
     },
   };
@@ -75,9 +80,62 @@ describe("createSharedCommands registry", () => {
       "cat",
       "grep",
       "ls",
+      "random",
       "theme",
       "whoami",
     ]);
+  });
+});
+
+describe("random (shared Command)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("rolls a page site-wide on bare random and navigates to it", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const { io, lines, navs } = makeIo();
+
+    await run(createSharedCommands(io), "random");
+
+    expect(lines[0]).toEqual({ text: "random", kind: CommandType.command });
+    expect(lines.at(-1)).toEqual({ text: "rolling the dice... About me", kind: CommandType.status });
+    expect(navs).toEqual(["/about/"]);
+  });
+
+  it("scopes the roll to a folder", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const { io, lines, navs } = makeIo();
+
+    await run(createSharedCommands(io), "random books");
+
+    expect(lines.at(-1)).toEqual({
+      text: "rolling the dice... The Dispossessed",
+      kind: CommandType.status,
+    });
+    expect(navs).toEqual(["/books/the-dispossessed/"]);
+  });
+
+  it("errors on an unknown folder without navigating", async () => {
+    const { io, lines, navs } = makeIo();
+
+    await run(createSharedCommands(io), "random nope");
+
+    expect(navs).toEqual([]);
+    expect(lines.at(-1)).toEqual({ text: "random: nope: no such folder", kind: CommandType.error });
+  });
+
+  it("errors when the scope has no pages to roll", async () => {
+    const { io, lines, navs } = makeIo();
+
+    // "about" is a leaf: the node itself doesn't count as a rollable page.
+    await run(createSharedCommands(io), "random about");
+
+    expect(navs).toEqual([]);
+    expect(lines.at(-1)).toEqual({
+      text: "random: nothing to roll in about",
+      kind: CommandType.error,
+    });
   });
 });
 

--- a/v2-blog/tests/unit/helpers/terminal/commands.test.ts
+++ b/v2-blog/tests/unit/helpers/terminal/commands.test.ts
@@ -17,20 +17,37 @@ vi.mock("../../../../src/_helpers/theme.ts", () => ({
   setTheme: setThemeMock,
 }));
 
+const fixtureEntries = vi.hoisted(() => [
+  { section: "pages", title: "About me", url: "/about/", description: "Who I am" },
+  { section: "blog", title: "Spinning vinyl", url: "/blog/2025/spinning-vinyl/", description: "A CSS record player" },
+  { section: "books", title: "The Dispossessed", url: "/books/the-dispossessed/", description: "Le Guin on walls" },
+]);
+
+vi.mock("../../../../src/_helpers/terminal/site-index.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../../src/_helpers/terminal/site-index.ts")>();
+  return { ...actual, fetchSiteIndex: () => Promise.resolve(fixtureEntries) };
+});
+
 import { createSharedCommands } from "../../../../src/_helpers/terminal/commands.ts";
 import { setIdentity } from "../../../../src/_helpers/identity.ts";
 import { CommandType } from "../../../../src/_helpers/terminal/core.ts";
 import { parseCommand } from "../../../../src/_helpers/terminal/parser.ts";
+import { flattenBlock, type Block } from "../../../../src/_helpers/terminal/blocks.ts";
 
 type Line = { text: string; kind: CommandType | undefined };
 
 function makeIo() {
   const lines: Line[] = [];
+  const blocks: Block[] = [];
   return {
     lines,
+    blocks,
     io: {
       append: async (text: string, _duration?: number, kind?: CommandType) => {
         lines.push({ text, kind });
+      },
+      render: async (block: Block) => {
+        blocks.push(block);
       },
     },
   };
@@ -54,7 +71,112 @@ beforeEach(() => {
 describe("createSharedCommands registry", () => {
   it("exposes exactly the shared Commands", () => {
     const { io } = makeIo();
-    expect(Object.keys(createSharedCommands(io)).sort()).toEqual(["theme", "whoami"]);
+    expect(Object.keys(createSharedCommands(io)).sort()).toEqual([
+      "cat",
+      "grep",
+      "ls",
+      "theme",
+      "whoami",
+    ]);
+  });
+});
+
+describe("ls (shared Command)", () => {
+  it("echoes the raw input as a command line first", async () => {
+    const { io, lines } = makeIo();
+    await run(createSharedCommands(io), "ls");
+    expect(lines[0]).toEqual({ text: "ls", kind: CommandType.command });
+  });
+
+  it("renders the root listing as a section block on bare ls", async () => {
+    const { io, blocks } = makeIo();
+    await run(createSharedCommands(io), "ls");
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].type).toBe("section");
+    const flat = flattenBlock(blocks[0]);
+    expect(flat).toContain("~/book_os");
+    expect(flat).toContain("blog/");
+    expect(flat).toContain("about");
+  });
+
+  it("prints a tree for a folder target", async () => {
+    const { io, lines } = makeIo();
+    await run(createSharedCommands(io), "ls blog");
+    expect(lines[1].text).toBe("blog/");
+    expect(lines.some((l) => l.text.includes("spinning-vinyl"))).toBe(true);
+  });
+
+  it("prints title and description for a leaf target", async () => {
+    const { io, lines } = makeIo();
+    await run(createSharedCommands(io), "ls spinning-vinyl");
+    expect(lines[1]).toEqual({ text: "Spinning vinyl", kind: CommandType.title });
+    expect(lines[2]).toEqual({ text: "A CSS record player", kind: CommandType.logdata });
+  });
+
+  it("errors on an unknown target", async () => {
+    const { io, lines } = makeIo();
+    await run(createSharedCommands(io), "ls nope");
+    expect(lines.at(-1)).toEqual({ text: "ls: nope: no such page", kind: CommandType.error });
+  });
+});
+
+describe("grep (shared Command)", () => {
+  it("prints usage without a term", async () => {
+    const { io, lines } = makeIo();
+    await run(createSharedCommands(io), "grep");
+    expect(lines.at(-1)).toEqual({ text: "usage: grep <term>", kind: CommandType.info });
+  });
+
+  it("matches titles case-insensitively and renders linked results", async () => {
+    const { io, blocks } = makeIo();
+    await run(createSharedCommands(io), "grep VINYL");
+    expect(blocks).toHaveLength(1);
+    const flat = flattenBlock(blocks[0]);
+    expect(flat).toContain("Spinning vinyl");
+    expect(flat).not.toContain("About me");
+  });
+
+  it("matches descriptions too", async () => {
+    const { io, blocks } = makeIo();
+    await run(createSharedCommands(io), "grep guin");
+    expect(flattenBlock(blocks[0])).toContain("The Dispossessed");
+  });
+
+  it("errors when nothing matches", async () => {
+    const { io, lines, blocks } = makeIo();
+    await run(createSharedCommands(io), "grep zzz");
+    expect(blocks).toHaveLength(0);
+    expect(lines.at(-1)).toEqual({ text: 'grep: no matches for "zzz"', kind: CommandType.error });
+  });
+});
+
+describe("cat (shared Command)", () => {
+  it("prints usage without a target", async () => {
+    const { io, lines } = makeIo();
+    await run(createSharedCommands(io), "cat");
+    expect(lines.at(-1)).toEqual({ text: "usage: cat <page>", kind: CommandType.info });
+  });
+
+  it("prints title and description for a page", async () => {
+    const { io, lines } = makeIo();
+    await run(createSharedCommands(io), "cat about");
+    expect(lines[1]).toEqual({ text: "About me", kind: CommandType.title });
+    expect(lines[2]).toEqual({ text: "Who I am", kind: CommandType.logdata });
+  });
+
+  it("refuses folders and points at ls", async () => {
+    const { io, lines } = makeIo();
+    await run(createSharedCommands(io), "cat blog");
+    expect(lines.at(-1)).toEqual({
+      text: "cat: blog: is a folder — try: ls blog",
+      kind: CommandType.error,
+    });
+  });
+
+  it("errors on an unknown target", async () => {
+    const { io, lines } = makeIo();
+    await run(createSharedCommands(io), "cat nope");
+    expect(lines.at(-1)).toEqual({ text: "cat: nope: no such page", kind: CommandType.error });
   });
 });
 

--- a/v2-blog/tests/unit/helpers/terminal/site-index.test.ts
+++ b/v2-blog/tests/unit/helpers/terminal/site-index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { buildTree, findNode, matchEntry, parseSiteIndex, renderRootListing, rootListingBlock, renderSubtree, resolveOpen, sanitizeNavQuery } from "../../../../src/_helpers/terminal/site-index.ts";
+import { buildTree, findNode, matchEntry, parseSiteIndex, renderRootListing, rootListingBlock, renderSubtree, resolveOpen, sanitizeNavQuery, searchEntries } from "../../../../src/_helpers/terminal/site-index.ts";
 
 const ENTRIES = parseSiteIndex([
   { section: "posts", title: "Why I never heard of Lit", url: "/blog/2025/why-i-never-heard-of-lit/" },
@@ -232,5 +232,26 @@ describe("resolveOpen", () => {
     expect(resolveOpen(root, ENTRIES, "ngrok")).toMatchObject({ kind: "navigate", url: "/blog/2025/using-ngrok-to-test-some-web-things/" });
     expect(resolveOpen(root, ENTRIES, "test").kind).toBe("ambiguous");
     expect(resolveOpen(root, ENTRIES, "zzz").kind).toBe("none");
+  });
+});
+
+describe("searchEntries", () => {
+  const searchable = parseSiteIndex([
+    { section: "posts", title: "Test driven fun", url: "/blog/2025/test-driven-fun/", description: "red green refactor" },
+    { section: "books", title: "Ring", url: "/books/ring/", description: "a cursed tape" },
+  ]);
+
+  it("matches titles case-insensitively", () => {
+    expect(searchEntries(searchable, "DRIVEN")).toHaveLength(1);
+    expect(searchEntries(searchable, "driven")[0].title).toBe("Test driven fun");
+  });
+
+  it("matches descriptions", () => {
+    expect(searchEntries(searchable, "cursed")[0].title).toBe("Ring");
+  });
+
+  it("returns nothing for a blank or unmatched term", () => {
+    expect(searchEntries(searchable, "   ")).toEqual([]);
+    expect(searchEntries(searchable, "zzz")).toEqual([]);
   });
 });

--- a/v2-blog/tests/unit/helpers/terminal/site-index.test.ts
+++ b/v2-blog/tests/unit/helpers/terminal/site-index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { buildTree, findNode, matchEntry, parseSiteIndex, renderRootListing, rootListingBlock, renderSubtree, resolveOpen, sanitizeNavQuery, searchEntries } from "../../../../src/_helpers/terminal/site-index.ts";
+import { buildTree, collectPages, findNode, matchEntry, parseSiteIndex, renderRootListing, rootListingBlock, renderSubtree, resolveOpen, sanitizeNavQuery, searchEntries } from "../../../../src/_helpers/terminal/site-index.ts";
 
 const ENTRIES = parseSiteIndex([
   { section: "posts", title: "Why I never heard of Lit", url: "/blog/2025/why-i-never-heard-of-lit/" },
@@ -232,6 +232,30 @@ describe("resolveOpen", () => {
     expect(resolveOpen(root, ENTRIES, "ngrok")).toMatchObject({ kind: "navigate", url: "/blog/2025/using-ngrok-to-test-some-web-things/" });
     expect(resolveOpen(root, ENTRIES, "test").kind).toBe("ambiguous");
     expect(resolveOpen(root, ENTRIES, "zzz").kind).toBe("none");
+  });
+});
+
+describe("collectPages", () => {
+  it("gathers every descendant carrying a page url, excluding the node itself", () => {
+    const root = buildTree(ENTRIES);
+
+    const all = collectPages(root);
+    expect(all.map((n) => n.url).sort()).toEqual([
+      "/about/",
+      "/blog/2025/test-driven-fun/",
+      "/blog/2025/using-ngrok-to-test-some-web-things/",
+      "/blog/2025/why-i-never-heard-of-lit/",
+      "/books/a-seca/",
+      "/books/ring/",
+    ]);
+
+    const books = collectPages(findNode(root, "books")!);
+    expect(books.map((n) => n.url).sort()).toEqual(["/books/a-seca/", "/books/ring/"]);
+  });
+
+  it("returns nothing for a leaf (the node itself doesn't count)", () => {
+    const root = buildTree(ENTRIES);
+    expect(collectPages(findNode(root, "about")!)).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## What

Resolves the books shell's part-stubbed Command surface (architecture review #7): every registered Command now does real work, and the working ones are Shared.

- **`ls` / `grep` / `cat` become Shared Commands** in `_helpers/terminal/commands.ts`, backed by the site index. The overlay's `_listContent` moves into the factory (byte-same behavior, `list` stays as an overlay alias); `grep <term>` searches titles + descriptions (new pure `searchEntries` in `site-index.ts`) and renders matches as a linked listing; `cat <page>` prints a page's title + description, refusing folders with a pointer to `ls`.
- **`git` stub deleted** from the books shell — it only echoed.
- **`clear` implemented** (scrollback pushed out of view, real-terminal style) with `cls` and `c` aliases — the mobile sidebar's "clear/c" button finally does what it says. `l` now aliases `list` for the same reason.
- `CommandIo` gains `render` (structured blocks), both help texts updated, CONTEXT.md's **Shared Command** entry now lists the full set.

## Why

The registry was wide but shallow: 4 of its Commands were echo-only stubs, and `clear` was advertised in the UI but dead. Implementing `ls`/`grep`/`cat` through the shared factory means both Terminal surfaces get identical semantics with one test suite owning them; deleting `git` shrinks the interface to what behaves.

## Verification

- `npm run check` green: 372 tests (338 → 372; +17 factory/site-index, drift guards on both surfaces, clear/alias/git-removal locks).
- Live-driven on both surfaces (Chrome): books shell `ls`/`grep the` (10 linked matches)/`cat about`/`clear`/`cls`, `git status` → "command not recognized"; summoned overlay `ls`/`grep coffee`/`cat ring` render the shared section blocks.
