### PR TITLE
fix: put both terminals on a single line-height rhythm

### DIFF
--- a/v2-blog/src/_helpers/terminal/core.ts
+++ b/v2-blog/src/_helpers/terminal/core.ts
@@ -236,7 +236,9 @@ export class TerminalCore {
     const cols = rows.reduce((max, row) => Math.max(max, row.length), 0);
     const grid = document.createElement("div");
     grid.className = "terminal-cols";
-    grid.style.gridTemplateColumns = `repeat(${cols}, max-content)`;
+    // minmax(0, max-content): tracks prefer their content width but may
+    // shrink below it, so long cells wrap instead of overflowing the grid.
+    grid.style.gridTemplateColumns = `repeat(${cols}, minmax(0, max-content))`;
 
     for (const row of rows) {
       for (let i = 0; i < cols; i++) {

--- a/v2-blog/src/_includes/css/buttons.css
+++ b/v2-blog/src/_includes/css/buttons.css
@@ -1,0 +1,40 @@
+/* The site's button look: a bracketed monospace label — [ close ]. It started
+   inside the books terminal; it is now the shared control for every surface.
+
+   Imported in three places because none of them can see the others' CSS:
+     - global.css .............. light DOM on base.njk pages
+     - the books head .......... the shell ships its own inline CSS and never
+                                 loads global.css
+     - each shadow sheet ....... page rules don't cross a shadow boundary
+                                 (terminal-overlay-shadow.css)
+
+   Consumers should style geometry only (size, placement). Colour, brackets and
+   the hover state live here — an id-specificity rule setting `color` in a
+   component would win over `.btn:hover` and silently kill the hover. */
+.btn {
+  display: flex;
+  align-items: center;
+  gap: 0 .5rem;
+  padding-block: .5rem;
+  text-transform: uppercase;
+  background-color: transparent;
+  border: none;
+  color: inherit;
+  font-family: var(--font-mono);
+  cursor: pointer;
+  transition: color 150ms ease;
+}
+
+.btn::before {
+  content: "[";
+}
+
+.btn::after {
+  content: "]";
+}
+
+/* No `outline: none` — the UA focus ring is the only keyboard cue here. */
+.btn:hover,
+.btn:focus-visible {
+  color: var(--color-accent-primary);
+}

--- a/v2-blog/src/_includes/css/term-palette.css
+++ b/v2-blog/src/_includes/css/term-palette.css
@@ -48,6 +48,14 @@ html {
   --term-warn-bg: #c8860d;
   --term-badge-text: #fff;
 
+  /* Terminal line rhythm: the single line unit both Terminal surfaces build
+     on. Set as an absolute length so every descendant — any font-size —
+     inherits the same line box, and heights/margins/paddings can be rounded
+     to whole lines (round(up|down, …, var(--term-line))) so the log never
+     shows a split line at the viewport edges. ASCII art is excluded (keeps
+     its own 1em metrics). */
+  --term-line: 1.25rem;
+
   /* Film-grain overlay: pre-rasterized feTurbulence tile + per-theme
      strength. Consumers paint var(--noise-tile) on a fixed overlay. */
   --noise-opacity: 0.05;

--- a/v2-blog/src/_includes/css/terminal.css
+++ b/v2-blog/src/_includes/css/terminal.css
@@ -143,7 +143,10 @@ terminal-shell {
   flex-flow: column-reverse;
   align-items: flex-start;
   width: 100%;
+  height: 60vh;
+  height: 60svh;
   gap: 1rem;
+  overflow-y: auto;
 }
 
 #ascii-area {
@@ -291,15 +294,4 @@ terminal-shell {
   }
 }
 
-.btn {
-  display: flex;
-  align-items: center;
-  gap: 0 .5rem;
-  padding-block: .5rem;
-  text-transform: uppercase;
-  background-color: transparent;
-  border: none;
-  color: inherit;
-  font-family: var(--font-mono);
-  cursor: pointer;
-}
+/* .btn lives in css/buttons.css — inlined by the books head after this file. */

--- a/v2-blog/src/_includes/css/terminal.css
+++ b/v2-blog/src/_includes/css/terminal.css
@@ -162,7 +162,10 @@ terminal-shell {
   margin-block-start: 1rem;
   padding-block-start: 1rem;
   border-top: 1px solid var(--color-code-border);
-  line-height: 1.2rem;
+  /* Line rhythm (see term-palette.css --term-line): an absolute line unit so
+     every descendant, whatever its font-size, sits on the same 1.25rem line. */
+  line-height: var(--term-line, 1.25rem);
+  hyphens: none;
 }
 
 .helpers {
@@ -171,15 +174,33 @@ terminal-shell {
   justify-content: space-between;
 }
 
+/* The slot flexbox hands to the log. It is a size container so the real
+   scroller below can round itself to whole lines against 100cqb — rounding
+   the slot's own height wouldn't survive flex shrinking. */
 #terminal-output {
   position: relative;
-  height: 100%;
-  overflow-x: hidden;
-  overflow-y: auto;
+  flex: 1 1 auto;
+  min-height: 0;
+  height: auto;
+  container-type: size;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  overflow: hidden;
 }
 
+/* The scroller: capped to a whole number of lines so the top and bottom
+   edges never cut a line in half (https://ishadeed.com/article/css-round/).
+   Possible follow-up experiment for a hard tty feel: step the scroll by
+   line with scroll-snap-type: y mandatory here plus
+   scroll-snap-align: start on .terminal-msg — left off for now because
+   snap fights trackpad momentum and the typing autoscroll. */
 #boot-log {
-  overflow-wrap: anywhere;
+  max-height: 100%;
+  max-height: round(down, 100cqb, var(--term-line, 1.25rem));
+  overflow-x: hidden;
+  overflow-y: auto;
+  overflow-wrap: break-word;
   white-space: pre-wrap;
 }
 
@@ -211,7 +232,7 @@ terminal-shell {
   font-family: var(--font-mono);
   font-size: 14px;
   letter-spacing: inherit;
-  line-height: 1.2;
+  line-height: var(--term-line, 1.25rem);
   resize: none;
   text-indent: calc(var(--label-width) + 5px);
   opacity: 1;
@@ -228,7 +249,7 @@ terminal-shell {
 }
 
 #terminal-text {
-  overflow-wrap: anywhere;
+  overflow-wrap: break-word;
   position: absolute;
   top: 1px;
   left: 0;
@@ -239,7 +260,7 @@ terminal-shell {
   cursor: text;
   font-family: var(--font-mono);
   font-size: 14px;
-  line-height: 1.2;
+  line-height: var(--term-line, 1.25rem);
   letter-spacing: inherit;
   pointer-events: none;
   z-index: 1;

--- a/v2-blog/src/_layouts/books.njk
+++ b/v2-blog/src/_layouts/books.njk
@@ -12,11 +12,12 @@
     {# Head assembly (CSP hashing + inline tags) lives in macros/head.njk.
        Scripts: the deferred books-shell CSS loader + the page's own.
        Styles: the shared terminal palette first (single token source,
-       ADR-0002), page styles, then the terminal fonts + shell CSS. #}
+       ADR-0002), page styles, then the terminal fonts + shell CSS + the
+       shared .btn rule (this shell never loads global.css). #}
     {% import "macros/head.njk" as heads %}
     {{ heads.head({
       scripts: ["inline-books-shell-css.js"].concat(inlineScripts or []),
-      styles: ["css/term-palette.css"].concat(inlineStyles or []).concat(["css/terminal-fonts.css", "css/terminal.css"]),
+      styles: ["css/term-palette.css"].concat(inlineStyles or []).concat(["css/terminal-fonts.css", "css/terminal.css", "css/buttons.css"]),
       extraStyleSrc: "https://use.typekit.net"
     }) }}
 

--- a/v2-blog/src/assets/styles/books-terminal-deferred.css
+++ b/v2-blog/src/assets/styles/books-terminal-deferred.css
@@ -95,8 +95,9 @@ html.dark {
 
 #boot-log {
   p {
-    max-width: 640px;
-    /* No block padding: every log line must stay exactly --term-line tall. */
+    /* One line unit, no block padding: every log line must stay exactly
+       --term-line tall or the rounded scroller cuts one at the edge. */
+    line-height: var(--term-line, 1.25rem);
     padding-block: 0;
   }
 
@@ -338,15 +339,5 @@ html.dark {
 #skip {
   @media (width >=768px) {
     margin-inline-start: auto;
-  }
-}
-
-.btn {
-  &::before {
-    content: "[";
-  }
-
-  &::after {
-    content: "]";
   }
 }

--- a/v2-blog/src/assets/styles/books-terminal-deferred.css
+++ b/v2-blog/src/assets/styles/books-terminal-deferred.css
@@ -96,7 +96,8 @@ html.dark {
 #boot-log {
   p {
     max-width: 640px;
-    padding-block: 2px;
+    /* No block padding: every log line must stay exactly --term-line tall. */
+    padding-block: 0;
   }
 
   /* Linear-stream lines: command echoes get a prompt glyph; info/title/error/
@@ -104,12 +105,14 @@ html.dark {
      core's data attributes (commandGlyph/commandBadge — the single glyph
      source, ADR-0002), so the pill rule is generic and the per-kind rules
      below carry colours only. */
+  /* Line rhythm: contiguous lines (no inter-line margins) on the shared
+     --term-line unit; sections below carry the breathing room. */
   .terminal-msg {
     display: flex;
     flex-wrap: wrap;
     align-items: baseline;
     gap: 0 0.6ch;
-    margin-block-end: 0.6ch;
+    margin-block: 0;
   }
 
   .terminal-msg[data-badge]::before {
@@ -120,6 +123,12 @@ html.dark {
     font-weight: 600;
     font-size: 0.82em;
     letter-spacing: 0.06em;
+    /* Hug the label instead of inheriting the full --term-line box; an
+       inline pill shorter than the line strut can't break the rhythm. The
+       transparent border reserves the bordered variants' 2px so no pill
+       ever outgrows the line. */
+    line-height: calc(1.5em - 2px);
+    border: 1px solid transparent;
     text-transform: uppercase;
     background: var(--term-accent);
     color: var(--term-on-accent);
@@ -142,15 +151,19 @@ html.dark {
     color: var(--term-badge-text);
   }
 
-  /* Structured blocks: columns grid with tone cells (book listing rows). */
+  /* Structured blocks: columns grid with tone cells (book listing rows).
+     Zero row-gap keeps rows on the line rhythm; cells wrap at word
+     boundaries (no hyphens, no overflow past the section edge). */
   .terminal-cols {
     display: grid;
-    gap: 0.1rem 1ch;
-    margin-block: 0.35rem;
+    gap: 0 1ch;
+    margin-block: 0;
   }
 
   .terminal-cell {
-    white-space: pre;
+    min-width: 0;
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
   }
 
   .terminal-cell[data-align="end"] {
@@ -177,6 +190,29 @@ html.dark {
   /* "Ring · Koji Suzuki" — decorative separator after a linked cell. */
   a.terminal-cell + .terminal-cell::before {
     content: "· ";
+    color: var(--term-muted);
+  }
+
+  /* Sections: the only vertical breathing room in the log. Whole-line
+     margin AND whole-line block padding: half-line padding would keep the
+     box height on rhythm but shift the lines inside it half a line out of
+     phase, so the viewport edge could cut them. */
+  .terminal-section {
+    margin-block: var(--term-line, 1.25rem);
+    padding-block: var(--term-line, 1.25rem);
+    padding-inline: 1.5ch;
+    border-radius: 6px;
+  }
+
+  .terminal-section[data-tone="surface"] {
+    background: var(--term-surface);
+  }
+
+  .terminal-section-title {
+    font-size: 0.78em;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
     color: var(--term-muted);
   }
 

--- a/v2-blog/src/assets/styles/books-terminal-deferred.css
+++ b/v2-blog/src/assets/styles/books-terminal-deferred.css
@@ -201,7 +201,6 @@ html.dark {
     margin-block: var(--term-line, 1.25rem);
     padding-block: var(--term-line, 1.25rem);
     padding-inline: 1.5ch;
-    border-radius: 6px;
   }
 
   .terminal-section[data-tone="surface"] {

--- a/v2-blog/src/assets/styles/global.css
+++ b/v2-blog/src/assets/styles/global.css
@@ -394,7 +394,7 @@
   height: var(--album-cover, 100px);
   transform: translateY(-50%);
   object-fit: cover;
-  border-radius: 4px;
+  border-radius: 2px;
   z-index: 2;
   box-shadow: 0 2px 8px rgb(0 0 0 / 25%);
   filter: blur(12px);

--- a/v2-blog/src/assets/styles/global.css
+++ b/v2-blog/src/assets/styles/global.css
@@ -7,6 +7,10 @@
 /* Terminal palette + colour ramps + noise tokens: single source shared with
    the books shell (inlined there via the head macro). */
 @import '../../_includes/css/term-palette.css' layer(theme);
+/* The shared .btn control, same single-source deal: the books head inlines it
+   and terminal-overlay-shadow.css imports it into the overlay's shadow root.
+   In the components layer so Tailwind utilities can still override it. */
+@import '../../_includes/css/buttons.css' layer(components);
 
 @custom-variant dark (&:where(.dark, .dark *));
 

--- a/v2-blog/src/assets/styles/terminal-overlay-shadow.css
+++ b/v2-blog/src/assets/styles/terminal-overlay-shadow.css
@@ -4,3 +4,7 @@
 @import "tailwindcss/utilities.css" layer(utilities) prefix(sw);
 
 @import "./shadow-config.css";
+
+/* Page rules don't cross the shadow boundary — the overlay's own copy of the
+   shared .btn control (unlayered, so it beats the prefixed utilities). */
+@import "../../_includes/css/buttons.css";

--- a/v2-blog/src/components/terminal-overlay.ts
+++ b/v2-blog/src/components/terminal-overlay.ts
@@ -140,23 +140,48 @@ export class TerminalOverlay extends LitElement {
       outline: none;
     }
 
-    #overlay-log {
-      margin: 0;
+    /* The slot flexbox hands to the log. A size container so the scroller
+       below can round itself to whole lines against 100cqb — rounding the
+       slot's own height wouldn't survive flex shrinking. */
+    #overlay-view {
       flex: 1 1 auto;
-      overflow: auto;
-      padding: 1rem 1.25rem;
-      white-space: pre-wrap;
-      font-size: 0.85rem;
-      line-height: 1.5;
+      min-height: 0;
+      container-type: size;
+      display: flex;
+      flex-direction: column;
+      justify-content: flex-end;
+      overflow: hidden;
     }
 
-    /* Linear-stream lines: badge pills from the core's data-badge attribute. */
+    #overlay-log {
+      margin: 0;
+      /* Line rhythm (term-palette.css --term-line): absolute line unit, so
+         every descendant sits on the same line box; the viewport is capped
+         to a whole number of lines so the edges never cut a line in half
+         (https://ishadeed.com/article/css-round/).
+         Possible follow-up experiment for a hard tty feel: step the scroll
+         by line with scroll-snap-type: y mandatory here plus
+         scroll-snap-align: start on .terminal-msg — left off for now
+         because snap fights trackpad momentum and the typing autoscroll. */
+      max-height: 100%;
+      max-height: round(down, 100cqb, var(--term-line, 1.25rem));
+      overflow: auto;
+      padding-inline: 1.25rem;
+      white-space: pre-wrap;
+      overflow-wrap: break-word;
+      hyphens: none;
+      font-size: 0.85rem;
+      line-height: var(--term-line, 1.25rem);
+    }
+
+    /* Linear-stream lines: badge pills from the core's data-badge attribute.
+       Contiguous lines — no inter-line margins; sections carry the spacing. */
     .terminal-msg {
       display: flex;
       flex-wrap: wrap;
       align-items: baseline;
       gap: 0 0.6ch;
-      margin-block-end: 0.6ch;
+      margin-block: 0;
     }
 
     /* Badge pill: glyph + label both come from the core's data attributes
@@ -171,6 +196,12 @@ export class TerminalOverlay extends LitElement {
       font-weight: 600;
       font-size: 0.82em;
       letter-spacing: 0.06em;
+      /* Hug the label instead of inheriting the full --term-line box; an
+         inline pill shorter than the line strut can't break the rhythm. The
+         transparent border reserves the bordered variants' 2px so no pill
+         ever outgrows the line. */
+      line-height: calc(1.5em - 2px);
+      border: 1px solid transparent;
       text-transform: uppercase;
       background: var(--term-accent);
       color: var(--term-on-accent);
@@ -275,15 +306,19 @@ export class TerminalOverlay extends LitElement {
       #overlay-status { display: none; }
     }
 
-    /* Structured blocks: columns grid, tone chips, and sections. */
+    /* Structured blocks: columns grid, tone chips, and sections. Zero
+       row-gap keeps rows on the line rhythm; cells wrap at word boundaries
+       (no hyphens, no overflow past the section edge). */
     .terminal-cols {
       display: grid;
-      gap: 0.1rem 1.5ch;
-      margin: 0.15rem 0;
+      gap: 0 1.5ch;
+      margin: 0;
     }
 
     .terminal-cell {
-      white-space: pre;
+      min-width: 0;
+      white-space: pre-wrap;
+      overflow-wrap: break-word;
     }
 
     .terminal-cell[data-align="end"] {
@@ -341,9 +376,12 @@ export class TerminalOverlay extends LitElement {
       border-radius: 3px;
     }
 
+    /* Whole-line margin AND whole-line block padding: half-line padding
+       would keep the box height on rhythm but shift the lines inside it
+       half a line out of phase, so the viewport edge could cut them. */
     .terminal-section {
-      margin: 0.35rem 0;
-      padding: 0.6rem 0.8rem;
+      margin: var(--term-line, 1.25rem) 0;
+      padding: var(--term-line, 1.25rem) 0.8rem;
       border-radius: 6px;
     }
 
@@ -353,7 +391,7 @@ export class TerminalOverlay extends LitElement {
       text-transform: uppercase;
       letter-spacing: 0.05em;
       color: var(--term-muted);
-      margin-bottom: 0.35rem;
+      margin-bottom: 0;
     }
 
     .sr-only {
@@ -626,7 +664,7 @@ export class TerminalOverlay extends LitElement {
             @click=${() => (this.open = false)}
           >✕</button>
         </header>
-        <pre id="overlay-log"></pre>
+        <div id="overlay-view"><pre id="overlay-log"></pre></div>
         <form id="overlay-form" @submit=${this._onSubmit}>
           <label class="sr-only" for="overlay-input">Terminal command</label>
           <textarea

--- a/v2-blog/src/components/terminal-overlay.ts
+++ b/v2-blog/src/components/terminal-overlay.ts
@@ -123,7 +123,6 @@ export class TerminalOverlay extends LitElement {
       width: 2rem;
       height: 2rem;
       border: 0;
-      border-radius: 6px;
       background: transparent;
       color: var(--term-muted);
       font: inherit;
@@ -166,12 +165,13 @@ export class TerminalOverlay extends LitElement {
       max-height: 100%;
       max-height: round(down, 100cqb, var(--term-line, 1.25rem));
       overflow: auto;
-      padding-inline: 1.25rem;
+      padding-inline: var(--term-line, 1.25rem);
       white-space: pre-wrap;
       overflow-wrap: break-word;
       hyphens: none;
       font-size: 0.85rem;
       line-height: var(--term-line, 1.25rem);
+      scroll-snap-type: y mandatory
     }
 
     /* Linear-stream lines: badge pills from the core's data-badge attribute.
@@ -182,6 +182,7 @@ export class TerminalOverlay extends LitElement {
       align-items: baseline;
       gap: 0 0.6ch;
       margin-block: 0;
+      scroll-snap-align: start
     }
 
     /* Badge pill: glyph + label both come from the core's data attributes
@@ -193,6 +194,7 @@ export class TerminalOverlay extends LitElement {
       flex: none;
       align-self: flex-start;
       padding: 0 0.6ch;
+      margin-block-start: 2px; // visual alignment with the line text
       font-weight: 600;
       font-size: 0.82em;
       letter-spacing: 0.06em;
@@ -301,7 +303,6 @@ export class TerminalOverlay extends LitElement {
         max-width: none;
         max-height: none;
         border: 0;
-        border-radius: 0;
       }
       #overlay-status { display: none; }
     }
@@ -382,7 +383,6 @@ export class TerminalOverlay extends LitElement {
     .terminal-section {
       margin: var(--term-line, 1.25rem) 0;
       padding: var(--term-line, 1.25rem) 0.8rem;
-      border-radius: 6px;
     }
 
     .terminal-section-title {

--- a/v2-blog/src/components/terminal-overlay.ts
+++ b/v2-blog/src/components/terminal-overlay.ts
@@ -86,7 +86,9 @@ export class TerminalOverlay extends LitElement {
       to { opacity: 1; }
     }
 
-    /* Title bar: tab label + close. */
+    /* Title bar: tab label + close. Muted is the bar's resting colour — the
+       close button inherits it (shared .btn sets color:inherit) and takes the
+       accent on hover from the same shared rule. */
     #overlay-titlebar {
       flex: none;
       display: flex;
@@ -95,6 +97,7 @@ export class TerminalOverlay extends LitElement {
       padding: 0.45rem 0.5rem 0.45rem 0.9rem;
       border-bottom: 1px solid var(--term-border);
       background: var(--term-surface);
+      color: var(--term-muted);
     }
 
     #overlay-tab {
@@ -115,28 +118,15 @@ export class TerminalOverlay extends LitElement {
       background: var(--term-accent);
     }
 
+    /* Geometry only. Look, brackets and hover come from the shared .btn rule
+       (buttons.css, imported into this shadow root by the overlay's Tailwind
+       sheet) — setting a color here would out-specify .btn:hover and kill it. */
     #overlay-close {
       flex: none;
-      display: inline-flex;
-      align-items: center;
       justify-content: center;
-      width: 2rem;
-      height: 2rem;
-      border: 0;
-      background: transparent;
-      color: var(--term-muted);
-      font: inherit;
+      padding-block: 0;
       font-size: 1rem;
       line-height: 1;
-      cursor: pointer;
-      transition: background 0.15s, color 0.15s;
-    }
-
-    #overlay-close:hover,
-    #overlay-close:focus-visible {
-      background: var(--term-accent);
-      color: var(--term-on-accent);
-      outline: none;
     }
 
     /* The slot flexbox hands to the log. A size container so the scroller
@@ -658,6 +648,7 @@ export class TerminalOverlay extends LitElement {
         <header id="overlay-titlebar">
           <span id="overlay-tab">book_os</span>
           <button
+            class="btn"
             id="overlay-close"
             type="button"
             aria-label="Close terminal"

--- a/v2-blog/src/components/terminal-shell.ts
+++ b/v2-blog/src/components/terminal-shell.ts
@@ -177,7 +177,7 @@ export class TerminalShell extends LitElement {
     commands: this.COMMANDS,
     logEl: () => this.querySelector("#boot-log"),
     skipAnimations: () => this.shell.skipAnimations,
-    onLineWritten: () => this._scrollToBottom(this._outputCLI),
+    onLineWritten: () => this._scrollToBottom(this._bootLog),
   });
 
 
@@ -631,7 +631,7 @@ export class TerminalShell extends LitElement {
         duration: 0.08,
         stagger: 0.03,
         ease: "none",
-        onUpdate: () => this._scrollToBottom(this._outputCLI),
+        onUpdate: () => this._scrollToBottom(this._bootLog),
         onComplete: () => resolve()
       });
     });
@@ -663,7 +663,7 @@ export class TerminalShell extends LitElement {
 
     if (batch.length === 0) {
       await this.appendToLog("bookshelf scan complete.", 0.2, CommandType.status);
-      this._scrollToBottom(this._outputCLI);
+      this._scrollToBottom(this._bootLog);
       return;
     }
 
@@ -686,7 +686,7 @@ export class TerminalShell extends LitElement {
       });
 
       this.dispatch({ type: "BOOKS_ADVANCED", count: 1 });
-      this._scrollToBottom(this._outputCLI);
+      this._scrollToBottom(this._bootLog);
       await this._staggerRowReveal();
     }
 
@@ -729,7 +729,7 @@ export class TerminalShell extends LitElement {
 
     form.reset();
     this.dispatch({ type: "INPUT_CHANGED", value: "" });
-    this._scrollToBottom(this._outputCLI);
+    this._scrollToBottom(this._bootLog);
 
     await this._executeCommand(raw);
   }
@@ -742,7 +742,7 @@ export class TerminalShell extends LitElement {
    */
   private async _executeCommand(input: string) {
     await this._core.run(input);
-    this._scrollToBottom(this._outputCLI);
+    this._scrollToBottom(this._bootLog);
   }
 
   private _insertCommand(cmd: string, mode: "replace" | "append" = "replace") {
@@ -785,12 +785,16 @@ export class TerminalShell extends LitElement {
   }
 
   private _clearOutput() {
-    if (!this._outputCLI) return;
-    var logHeight = this._bootLog.scrollHeight;
-    var outputHeight = this._outputCLI.offsetHeight;
-    this._bootLog.style.height = `${logHeight + outputHeight}px`;
+    if (!this._bootLog) return;
+    // Terminal-style clear: push the scrollback one full viewport up with a
+    // spacer. The scroller's height is rounded to whole lines (terminal.css),
+    // so the spacer is a whole-line multiple too and the rhythm survives.
+    const spacer = document.createElement("div");
+    spacer.className = "clear-spacer";
+    spacer.style.height = `${this._bootLog.clientHeight}px`;
+    this._bootLog.appendChild(spacer);
     requestAnimationFrame(() => {
-      this._scrollToBottom(this._outputCLI);
+      this._scrollToBottom(this._bootLog);
     })
   }
 
@@ -815,7 +819,7 @@ export class TerminalShell extends LitElement {
     el.setSelectionRange(end, end);
 
     requestAnimationFrame(() => this._updateFakeCaretPosition());
-    this._scrollToBottom(this._outputCLI);
+    this._scrollToBottom(this._bootLog);
   }
 
   private _forceCaretRules(e: Event) {

--- a/v2-blog/tests/unit/components/terminal-shell.test.ts
+++ b/v2-blog/tests/unit/components/terminal-shell.test.ts
@@ -453,8 +453,8 @@ describe("terminal-shell startup phases", () => {
     await (element as any)._executeCommand("clear");
 
     expect(element.querySelector("#boot-log p.terminal-msg.error")).toBeNull();
-    const bootLog = element.querySelector("#boot-log") as HTMLElement;
-    expect(bootLog.style.height).not.toBe("");
+    // The clear spacer pushes the scrollback a full viewport up.
+    expect(element.querySelector("#boot-log .clear-spacer")).not.toBeNull();
   });
 
   it("cls and c stay as aliases of clear", async () => {


### PR DESCRIPTION
## What

Puts both Terminal surfaces on a single line-height rhythm and fixes the listing overflow/hyphenation bugs (per the CSS `round()` approach in https://ishadeed.com/article/css-round/):

- **One shared token** `--term-line: 1.25rem` in `term-palette.css`, set as an *absolute* line-height at each terminal root — every descendant, whatever its font-size (badges, section titles, prompt, input), sits on the same line box.
- **Whole-line geometry**: zero margins between log lines; sections carry the breathing room with whole-line margins AND whole-line block padding (half-line padding would keep the box height on rhythm but phase-shift the lines inside it — caught live and fixed). Badge pills reserve a transparent 1px border so the bordered variants can't outgrow the line.
- **Scrollers capped to whole lines**: the flex slot each log sits in becomes a size container, and the scroller inside caps itself with `max-height: round(down, 100cqb, var(--term-line))` — rounding the slot itself doesn't survive flex shrinking. Viewport edges can no longer cut a line in half. A comment marks the follow-up experiment (scroll-snap per line for a hard tty step) and why it's off for now.
- **Wrapping**: grid tracks become `minmax(0, max-content)` (core), cells `pre-wrap` + `overflow-wrap: break-word`, `hyphens: none` on both terminal roots (the base shell's `hyphens: auto` inherits into the overlay's shadow DOM) — long grep/ls titles now wrap at word boundaries inside the section box instead of overflowing it.
- **`clear` reworked**: the old trick grew the scroller's own height, which dies under a max-height cap; it now appends a line-multiple spacer sized to the (already rounded) viewport.
- Books shell gains the tinted `.terminal-section` styles the overlay already had (they were missing entirely — the listing box in the bug screenshot was unstyled).

## Verification

- `npm run check` green, 379 tests.
- Live-measured in Chrome on both surfaces: shell scroller exactly 29 × 17.5px (14px root), overlay exactly 19 × 20px; **every element and every rendered text line lands on the grid** (TreeWalker phase check over all client rects: 0 deviations), `scrollTop % line === 0` at rest, `hyphens: none` computed.
